### PR TITLE
fix traces

### DIFF
--- a/models/silver/traces/silver__traces.sql
+++ b/models/silver/traces/silver__traces.sql
@@ -37,7 +37,9 @@ LIMIT
                 block_id
             FROM
                 new_blocks
-        )
+        ) qualify(ROW_NUMBER() over(PARTITION BY tx_id
+    ORDER BY
+        ingested_at DESC)) = 1
 ),
 base_table AS (
     SELECT


### PR DESCRIPTION
- see tx `0x0e51c8b1312161aa825c7693e4cd36335b671a3b5acfa8f70240cad2b01b3766` for bug (two ingested at dates)
- if we replay a block into chainwalkers and the prior version has an incorrect record, the incorrect record stays in the table even if we delete and replay the block 
- i will have to delete and replay ~350k blocks into traces