### PR TITLE
Streamline Completed Balances Optimizations

### DIFF
--- a/models/silver/streamline/streamline__complete_eth_balances.sql
+++ b/models/silver/streamline/streamline__complete_eth_balances.sql
@@ -36,21 +36,23 @@ WHERE
             COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
         FROM
             {{ this }})
-        {% endif %}
-        SELECT
-            block_number,
-            address,
-            {{ dbt_utils.surrogate_key(
-                ['block_number', 'address']
-            ) }} AS id,
-            m.registered_on AS _inserted_timestamp
-        FROM
-            {{ source(
-                "bronze_streamline",
-                "eth_balances"
-            ) }} AS s
-            JOIN meta m
-            ON m.file_name = metadata$filename
+        {% else %}
+    )
+{% endif %}
+SELECT
+    block_number,
+    address,
+    {{ dbt_utils.surrogate_key(
+        ['block_number', 'address']
+    ) }} AS id,
+    m.registered_on AS _inserted_timestamp
+FROM
+    {{ source(
+        "bronze_streamline",
+        "eth_balances"
+    ) }} AS s
+    JOIN meta m
+    ON m.file_name = metadata$filename
 
 {% if is_incremental() %}
 JOIN partitions p

--- a/models/silver/streamline/streamline__complete_eth_balances.sql
+++ b/models/silver/streamline/streamline__complete_eth_balances.sql
@@ -8,7 +8,7 @@
 WITH meta AS (
 
     SELECT
-        last_modified,
+        registered_on,
         file_name
     FROM
         TABLE(
@@ -16,38 +16,50 @@ WITH meta AS (
                 table_name => '{{ source( "bronze_streamline", "eth_balances") }}'
             )
         ) A
-    GROUP BY
-        last_modified,
-        file_name
-)
-
-{% if is_incremental() %},
-max_date AS (
-    SELECT
-        COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
-    FROM
-        {{ this }})
-    {% endif %}
-    SELECT
-        block_number,
-        address,
-        concat_ws(
-            '-',
-            block_number,
-            address
-        ) AS id,
-        last_modified AS _inserted_timestamp
-    FROM
-        {{ source(
-            "bronze_streamline",
-            "eth_balances"
-        ) }}
-        JOIN meta b
-        ON b.file_name = metadata$filename
 
 {% if is_incremental() %}
 WHERE
-    b.last_modified > (
+    registered_on >= (
+        SELECT
+            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
+        FROM
+            {{ this }})
+    ),
+    partitions AS (
+        SELECT
+            DISTINCT TO_NUMBER(SPLIT_PART(file_name, '/', 3)) AS partition_block_id
+        FROM
+            meta
+    ),
+    max_date AS (
+        SELECT
+            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
+        FROM
+            {{ this }})
+        {% endif %}
+        SELECT
+            block_number,
+            address,
+            {{ dbt_utils.surrogate_key(
+                ['block_number', 'address']
+            ) }} AS id,
+            m.registered_on AS _inserted_timestamp
+        FROM
+            {{ source(
+                "bronze_streamline",
+                "eth_balances"
+            ) }} AS s
+            JOIN meta m
+            ON m.file_name = metadata$filename
+
+{% if is_incremental() %}
+JOIN partitions p
+ON p.partition_block_id = s._partition_by_block_id
+{% endif %}
+
+{% if is_incremental() %}
+WHERE
+    m.registered_on > (
         SELECT
             max_INSERTED_TIMESTAMP
         FROM

--- a/models/silver/streamline/streamline__complete_token_balances.sql
+++ b/models/silver/streamline/streamline__complete_token_balances.sql
@@ -36,22 +36,24 @@ WHERE
             COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
         FROM
             {{ this }})
-        {% endif %}
-        SELECT
-            block_number,
-            address,
-            contract_address,
-            {{ dbt_utils.surrogate_key(
-                ['block_number', 'contract_address', 'address']
-            ) }} AS id,
-            m.registered_on AS _inserted_timestamp
-        FROM
-            {{ source(
-                "bronze_streamline",
-                "token_balances"
-            ) }} AS s
-            JOIN meta m
-            ON m.file_name = metadata$filename
+        {% else %}
+    )
+{% endif %}
+SELECT
+    block_number,
+    address,
+    contract_address,
+    {{ dbt_utils.surrogate_key(
+        ['block_number', 'contract_address', 'address']
+    ) }} AS id,
+    m.registered_on AS _inserted_timestamp
+FROM
+    {{ source(
+        "bronze_streamline",
+        "token_balances"
+    ) }} AS s
+    JOIN meta m
+    ON m.file_name = metadata$filename
 
 {% if is_incremental() %}
 JOIN partitions p

--- a/models/silver/streamline/streamline__complete_token_balances.sql
+++ b/models/silver/streamline/streamline__complete_token_balances.sql
@@ -8,7 +8,7 @@
 WITH meta AS (
 
     SELECT
-        last_modified,
+        registered_on,
         file_name
     FROM
         TABLE(
@@ -16,40 +16,51 @@ WITH meta AS (
                 table_name => '{{ source( "bronze_streamline", "token_balances") }}'
             )
         ) A
-    GROUP BY
-        last_modified,
-        file_name
-)
-
-{% if is_incremental() %},
-max_date AS (
-    SELECT
-        COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
-    FROM
-        {{ this }})
-    {% endif %}
-    SELECT
-        block_number,
-        address,
-        contract_address,
-        concat_ws(
-            '-',
-            block_number,
-            address,
-            contract_address
-        ) AS id,
-        last_modified AS _inserted_timestamp
-    FROM
-        {{ source(
-            "bronze_streamline",
-            "token_balances"
-        ) }}
-        JOIN meta b
-        ON b.file_name = metadata$filename
 
 {% if is_incremental() %}
 WHERE
-    b.last_modified > (
+    registered_on >= (
+        SELECT
+            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
+        FROM
+            {{ this }})
+    ),
+    partitions AS (
+        SELECT
+            DISTINCT TO_NUMBER(SPLIT_PART(file_name, '/', 3)) AS partition_block_id
+        FROM
+            meta
+    ),
+    max_date AS (
+        SELECT
+            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
+        FROM
+            {{ this }})
+        {% endif %}
+        SELECT
+            block_number,
+            address,
+            contract_address,
+            {{ dbt_utils.surrogate_key(
+                ['block_number', 'contract_address', 'address']
+            ) }} AS id,
+            m.registered_on AS _inserted_timestamp
+        FROM
+            {{ source(
+                "bronze_streamline",
+                "token_balances"
+            ) }} AS s
+            JOIN meta m
+            ON m.file_name = metadata$filename
+
+{% if is_incremental() %}
+JOIN partitions p
+ON p.partition_block_id = s._partition_by_block_id
+{% endif %}
+
+{% if is_incremental() %}
+WHERE
+    m.registered_on > (
         SELECT
             max_INSERTED_TIMESTAMP
         FROM


### PR DESCRIPTION
- optimize models to avoid table scans using partition pruning
- use registered_on instead of last_modified for incremental logic