### PR TITLE
add synthetix swaps silver table

### DIFF
--- a/models/silver/dex/silver_dex__synthetix_swaps.sql
+++ b/models/silver/dex/silver_dex__synthetix_swaps.sql
@@ -1,0 +1,148 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "_log_id",
+    cluster_by = ['block_timestamp::DATE']
+) }}
+-- build base table
+WITH synthetix_swaps_base AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        'synthetix' AS "POOL_NAME",
+        'Swap' AS "EVENT_NAME",
+        origin_from_address AS "SENDER",
+        SUBSTR(
+            event_inputs :toAddress,
+            1,
+            42
+        ) AS "TX_TO",
+        -- substr to remove " at the end and start of tx_to
+        -- 18 decimals is hardcoded on the synth contracts https://docs.synthetix.io/contracts/source/contracts/Synth/
+        event_inputs :fromAmount / 10e18 AS "AMOUNT_IN",
+        event_inputs :toAmount / 10e18 AS "AMOUNT_OUT",
+        event_index,
+        'synthetix' AS "PLATFORM",
+        -- remove "0x" from the start of the currency key -> decode value -> filter out null characters
+        REGEXP_REPLACE(
+            HEX_DECODE_STRING(SUBSTR(event_inputs :fromCurrencyKey, 3, 64)),
+            '[^a-zA-Z0-9]+'
+        ) AS "SYMBOL_IN",
+        REGEXP_REPLACE(
+            HEX_DECODE_STRING(SUBSTR(event_inputs :toCurrencyKey, 3, 64)),
+            '[^a-zA-Z0-9]+'
+        ) AS "SYMBOL_OUT",
+        CONCAT(
+            tx_hash,
+            '-',
+            event_index
+        ) AS _log_id,
+        event_inputs,
+        contract_address,
+        _inserted_timestamp,
+        -- used for incremental materialization,
+        DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) AS swap_hour -- helper column
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        1 = 1
+        AND contract_address IN (
+            '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
+            '0xc011a72400e58ecd99ee497cf89e3775d4bd732f'
+        ) -- synthetics proxy
+        AND event_name = 'SynthExchange'
+),
+-- get token addresses
+synthetix_swaps_with_token_addresses AS (
+    SELECT
+        *
+    FROM
+        synthetix_swaps_base
+        LEFT JOIN (
+            SELECT
+                synth_symbol AS synth_symbol_in,
+                synth_proxy_address AS token_in
+            FROM
+                {{ ref('silver__synthetix_synths') }}
+        ) synths_in
+        ON synths_in.synth_symbol_in = synthetix_swaps_base.symbol_in
+        LEFT JOIN (
+            SELECT
+                synth_symbol AS synth_symbol_out,
+                synth_proxy_address AS token_out
+            FROM
+                {{ ref('silver__synthetix_synths') }}
+        ) synths_out
+        ON synths_out.synth_symbol_out = synthetix_swaps_base.symbol_out
+),
+-- add token prices
+synthetix_swaps_final AS (
+    SELECT
+        synthetix_swaps_with_token_addresses.block_number,
+        synthetix_swaps_with_token_addresses.block_timestamp,
+        synthetix_swaps_with_token_addresses.tx_hash,
+        synthetix_swaps_with_token_addresses.origin_function_signature,
+        synthetix_swaps_with_token_addresses.origin_from_address,
+        synthetix_swaps_with_token_addresses.origin_to_address,
+        synthetix_swaps_with_token_addresses.contract_address AS contract_address,
+        synthetix_swaps_with_token_addresses.pool_name,
+        synthetix_swaps_with_token_addresses.event_name,
+        synthetix_swaps_with_token_addresses.amount_in,
+        synthetix_swaps_with_token_addresses.amount_in * prices_in.price_in AS amount_in_usd,
+        synthetix_swaps_with_token_addresses.amount_out,
+        synthetix_swaps_with_token_addresses.amount_out * prices_out.price_out AS amount_out_usd,
+        synthetix_swaps_with_token_addresses.sender,
+        synthetix_swaps_with_token_addresses.tx_to,
+        synthetix_swaps_with_token_addresses.event_index,
+        synthetix_swaps_with_token_addresses.platform,
+        synthetix_swaps_with_token_addresses.token_in,
+        synthetix_swaps_with_token_addresses.token_out,
+        synthetix_swaps_with_token_addresses.symbol_in,
+        synthetix_swaps_with_token_addresses.symbol_out,
+        synthetix_swaps_with_token_addresses._log_id,
+        synthetix_swaps_with_token_addresses._inserted_timestamp
+    FROM
+        synthetix_swaps_with_token_addresses
+        LEFT JOIN (
+            SELECT
+                HOUR AS hour_in,
+                price AS price_in,
+                token_address AS token_address_in
+            FROM
+                ethereum_community_dev.core.fact_hourly_token_prices
+        ) prices_in
+        ON prices_in.token_address_in = synthetix_swaps_with_token_addresses.token_in
+        AND prices_in.hour_in = synthetix_swaps_with_token_addresses.swap_hour
+        LEFT JOIN (
+            SELECT
+                HOUR AS hour_out,
+                price AS price_out,
+                token_address AS token_address_out
+            FROM
+                ethereum_community_dev.core.fact_hourly_token_prices
+        ) prices_out
+        ON prices_out.token_address_out = synthetix_swaps_with_token_addresses.token_out
+        AND prices_out.hour_out = synthetix_swaps_with_token_addresses.swap_hour
+)
+SELECT
+    *
+FROM
+    synthetix_swaps_final
+WHERE
+    1 = 1
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}

--- a/models/silver/dex/silver_dex__synthetix_swaps.sql
+++ b/models/silver/dex/silver_dex__synthetix_swaps.sql
@@ -99,9 +99,9 @@ filtered_hourly_prices AS (
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     {% if is_incremental() %}
-    AND hour >= (
+    WHERE hour >= (
         SELECT
-            min(block_timestamp)
+            min(date_trunc('hour', block_timestamp))
         FROM
             synthetix_swaps_base
     )

--- a/models/silver/dex/silver_dex__synthetix_swaps.yml
+++ b/models/silver/dex/silver_dex__synthetix_swaps.yml
@@ -1,0 +1,192 @@
+version: 2
+models:
+  - name: silver_dex__synthetix_swaps
+    description: A record of all swaps in the Synthetix DEX on Ethereum mainnet
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _log_id
+    columns:
+      - name: BLOCK_NUMBER
+        description: '{{ doc("eth_block_number") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("eth_block_timestamp") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        description: '{{ doc("eth_tx_hash") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: Function signature from the transaction that originated the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: ORIGIN_FROM_ADDRESS
+        description: Address that initiated the transaction that originated the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: ORIGIN_TO_ADDRESS
+        description: Receiving party of the transaction that originated the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: CONTRACT_ADDRESS
+        description: '{{ doc("eth_contracts_name") }}' 
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_NAME
+        description: Always 'Swap'
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: AMOUNT_IN
+        description: Amount of tokens entering the swap (decimal adjusted)
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: AMOUNT_IN_USD
+        description: Approximate Amount of USD entering the swap
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: AMOUNT_OUT
+        description: Amount of tokens exiting the swap (decimal adjusted)
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: AMOUNT_OUT_USD
+        description: Approximate Amount of USD exiting the swap
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: SENDER
+        description: Same as origin_from_address
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        description: the "to" field in the swap event log
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        description: index of the event log of the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: PLATFORM
+        description: platform in which the swap is happening. always "Synthetix"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TOKEN_IN
+        description: address of the token entering the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TOKEN_OUT
+        description: address of the token exiting the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_IN
+        description: symbol (ticker) of the token entering the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        description: symbol (ticker) of the token exiting the swap
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: _LOG_ID
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR


### PR DESCRIPTION
add synthetix swaps silver table following the specifications given by Flipside in [this doc](https://docs.google.com/document/d/1kPUehVFgqsiepXbqddXINw_P2Mf4JIFyQ7yQZODQ-qs/edit#)

the logs for the tests covering recency, nulls, duplicates and data type checks can be found below
[test_logs_synthetixs_table.log](https://github.com/FlipsideCrypto/ethereum-models/files/9531812/test_logs_synthetixs_table.log)