### PR TITLE
An 1961 fix ethereum nft bug

### DIFF
--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -259,6 +259,13 @@ all_transfers AS (
         punk_bought b
         INNER JOIN transfers A
         ON A.event_index -1 = b.event_index
+     where 
+        tx_status = 'SUCCESS'
+        AND A.tx_hash IN (
+            '0xbf12a064d822538bd23ba0a79091b2f0b669f084440d7b653d203154be34e2ad',
+            '0x1885ba1f18b3f417c681089629bd15cc9fc4ef799e0a3e0550804fd8bb7571dd'
+        )
+        AND A.block_timestamp :: DATE = '2017-12-17'
     UNION ALL
     SELECT
         _log_id,

--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -125,7 +125,7 @@ punk_bought AS (
         {{ref('silver__logs')}}
     WHERE
         event_name ILIKE '%punkbought%' 
-        -- AND  to_ADDRESS = '0x0000000000000000000000000000000000000000'
+        AND  to_ADDRESS <> '0x0000000000000000000000000000000000000000'
         -- AND tx_hash in ('0xbf12a064d822538bd23ba0a79091b2f0b669f084440d7b653d203154be34e2ad','0x1885ba1f18b3f417c681089629bd15cc9fc4ef799e0a3e0550804fd8bb7571dd')
         -- AND tx_status = 'Success'
         -- AND contract_address = LOWER('0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB')

--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -5,8 +5,43 @@
     tags = ['core']
 ) }}
 
-WITH transfers AS (
+WITH logdata AS (
 
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        event_index,
+        contract_address,
+        event_name,
+        topics,
+        event_inputs,
+        DATA,
+        ingested_at,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        tx_status = 'SUCCESS'
+        AND tx_hash IN (
+            '0xbf12a064d822538bd23ba0a79091b2f0b669f084440d7b653d203154be34e2ad',
+            '0x1885ba1f18b3f417c681089629bd15cc9fc4ef799e0a3e0550804fd8bb7571dd'
+        )
+        AND block_timestamp :: DATE = '2017-12-17'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        )
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+transfers AS (
     SELECT
         _log_id,
         block_number,
@@ -58,7 +93,7 @@ WITH transfers AS (
         ingested_at,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs') }}
+        logdata
     WHERE
         (
             event_name IN (
@@ -71,28 +106,14 @@ WITH transfers AS (
             )
         )
         AND nft_tokenid IS NOT NULL
-        AND tx_status = 'SUCCESS'
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
+),
+punk_bought AS (
     SELECT
-        MAX(
-            _inserted_timestamp
-        )
-    FROM
-        {{ this }}
-)
-{% endif %}
-)
-
-,punk_bought AS (
-        
-    SELECT
-        _log_id, 
-         block_number,
+        _log_id,
+        block_number,
         tx_hash,
         block_timestamp,
-        event_index, 
+        event_index,
         contract_address :: STRING AS contract_address,
         CASE
             WHEN event_name IN (
@@ -105,7 +126,6 @@ AND _inserted_timestamp >= (
                 event_inputs :fromAddress :: STRING
             )
             WHEN topics [0] :: STRING = '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3' THEN CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40))
-           
         END AS from_address,
         CASE
             WHEN event_name IN (
@@ -118,7 +138,6 @@ AND _inserted_timestamp >= (
                 event_inputs :toAddress :: STRING
             )
             WHEN topics [0] :: STRING = '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3' THEN CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))
-           
         END AS to_address,
         CASE
             WHEN event_name IN (
@@ -133,32 +152,17 @@ AND _inserted_timestamp >= (
             WHEN topics [0] :: STRING = '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3' THEN PUBLIC.udf_hex_to_int(
                 DATA :: STRING
             )
-           
-            
         END AS nft_tokenid,
         event_inputs :_value :: STRING AS erc1155_value,
         ingested_at,
         _inserted_timestamp
-    FROM silver.logs
-    WHERE 
-    event_name ilike '%punkbought%'
-        -- to_ADDRESS != '0x0000000000000000000000000000000000000000'
-         -- AND contract_address = LOWER('0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB')
-        AND tx_status = 'SUCCESS'
-
- {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(
-            _inserted_timestamp
-        )
     FROM
-        {{ this }}
-)
-{% endif %}
-)   
--- next step handles the case where event names are not decoded
-,find_missing_events AS (
+        logdata
+    WHERE
+        event_name ILIKE '%punkbought%' -- to_ADDRESS != '0x0000000000000000000000000000000000000000'
+        -- AND contract_address = LOWER('0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB')
+),
+find_missing_events AS (
     SELECT
         _log_id,
         block_number,
@@ -200,7 +204,7 @@ AND _inserted_timestamp >= (
         ingested_at,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs') }}
+        logdata
     WHERE
         event_name IS NULL
         AND (
@@ -216,21 +220,10 @@ AND _inserted_timestamp >= (
         )
         AND contract_address IN (
             SELECT
-                DISTINCT contract_address
+                contract_address
             FROM
                 transfers
         )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(
-            _inserted_timestamp
-        )
-    FROM
-        {{ this }}
-)
-{% endif %}
 ),
 all_transfers AS (
     SELECT
@@ -249,23 +242,23 @@ all_transfers AS (
     FROM
         transfers A
     UNION ALL
-    SELECT 
-         B._log_id,
-         B.block_number,
-         B.tx_hash,
-         B.block_timestamp,
-         B.contract_address,
-         B.from_address,
-         B.to_address,
-         B.nft_tokenid AS tokenId,
-         B.erc1155_value,
-         B.ingested_at,
-         B._inserted_timestamp,
-         B.event_index
+    SELECT
+        b._log_id,
+        b.block_number,
+        b.tx_hash,
+        b.block_timestamp,
+        b.contract_address,
+        b.from_address,
+        b.to_address,
+        b.nft_tokenid AS tokenId,
+        b.erc1155_value,
+        b.ingested_at,
+        b._inserted_timestamp,
+        b.event_index
     FROM
-        punk_bought B
-    INNER JOIN transfers A 
-    ON A.event_index -1 = B.event_index
+        punk_bought b
+        INNER JOIN transfers A
+        ON A.event_index -1 = b.event_index
     UNION ALL
     SELECT
         _log_id,


### PR DESCRIPTION
fix NFT_transfer table to pull the correct tokenId and have no null values in the to_address column.  Some to_address still indicate the burn address instead of the wallet address because that's how they are in the silver.logs table, and the data is pulled from there. 