### PR TITLE
An 2516/lp-actions-col-adj

### DIFF
--- a/models/uniswapv3/silver/silver__univ3_lp_actions.sql
+++ b/models/uniswapv3/silver/silver__univ3_lp_actions.sql
@@ -66,8 +66,7 @@ lp_amounts AS (
             WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN 'INCREASE_LIQUIDITY'
         END AS action,
         contract_address AS pool_address,
-        origin_from_address,
-        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS liquidity_provider,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS vault_address,
         PUBLIC.udf_hex_to_int(
             's2c',
             topics [2] :: STRING
@@ -224,13 +223,12 @@ FINAL AS (
         p1.price AS token1_price,
         A.amount :: INTEGER AS liquidity,
         liquidity / pow(10, (token1_decimals + token0_decimals) / 2) AS liquidity_adjusted,
-        -- CASE
-        --     WHEN nf_position_manager_address IS NOT NULL THEN origin_from_address
-        --     ELSE liquidity_provider
-        -- END AS
         A.origin_from_address AS liquidity_provider,
-        nf_position_manager_address,
         nf_token_id,
+        CASE
+            WHEN nf_token_id IS NULL THEN vault_address
+            ELSE nf_position_manager_address
+        END AS nf_position_manager_address,
         pool_address,
         pool_name,
         A.tick_lower AS tick_lower,

--- a/models/uniswapv3/silver/silver__univ3_lp_actions.sql
+++ b/models/uniswapv3/silver/silver__univ3_lp_actions.sql
@@ -66,6 +66,7 @@ lp_amounts AS (
             WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN 'INCREASE_LIQUIDITY'
         END AS action,
         contract_address AS pool_address,
+        origin_from_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS liquidity_provider,
         PUBLIC.udf_hex_to_int(
             's2c',
@@ -227,7 +228,7 @@ FINAL AS (
         --     WHEN nf_position_manager_address IS NOT NULL THEN origin_from_address
         --     ELSE liquidity_provider
         -- END AS
-        liquidity_provider,
+        A.origin_from_address AS liquidity_provider,
         nf_position_manager_address,
         nf_token_id,
         pool_address,

--- a/models/uniswapv3/silver/silver__univ3_position_collected_fees.sql
+++ b/models/uniswapv3/silver/silver__univ3_position_collected_fees.sql
@@ -34,7 +34,7 @@ collected_base AS (
     SELECT
         *,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS liquidity_provider,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS vault_address,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS owner,
         PUBLIC.udf_hex_to_int(
             's2c',
@@ -126,7 +126,10 @@ SELECT
     pool_name,
     b.origin_from_address AS liquidity_provider,
     nf_token_id,
-    nf_position_manager_address,
+    CASE
+        WHEN nf_token_id IS NULL THEN vault_address
+        ELSE nf_position_manager_address
+    END AS nf_position_manager_address,
     token0_symbol,
     token1_symbol,
     b.amount0,


### PR DESCRIPTION
1. Modified `liquidity_provider` and `nf_position_manager_address` columns based on corrected logic so that models have column parity with eachother
2. Associated downstream uniswap v3 models will require a full refresh (silver + core lp_actions, position_collected_fees, positions)
3. [Ticket](https://team-1612274056224.atlassian.net/browse/AN-2516)