### PR TITLE
fix/null-nftokenid-univ3

### DIFF
--- a/models/uniswapv3/silver/silver__univ3_positions.sql
+++ b/models/uniswapv3/silver/silver__univ3_positions.sql
@@ -36,7 +36,7 @@ WITH lp_events AS (
     FROM
         {{ ref('silver__univ3_lp_actions') }}
     WHERE
-        nf_position_manager_address IS NOT NULL
+        nf_token_id IS NOT NULL
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (


### PR DESCRIPTION
1. After `univ3_lp_actions` table was modified for more accurate `nf_position_manager_addresses`, the `univ3_positions` table was indexing on non-null `nf_position_managers` when it should have been on non-null `nf_token_id`
2. Requires full refresh