### PR TITLE
fix/dbt-env-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ logs/
 .vscode/
 .env
 .user.yml
+dbt-env/


### PR DESCRIPTION
1. Added "dbt-env/" to the .gitignore file for SSO purposes