### PR TITLE
AN-2753/incorrect-decimals

### DIFF
--- a/models/silver/silver__token_meta_reads.sql
+++ b/models/silver/silver__token_meta_reads.sql
@@ -14,6 +14,7 @@ heal_table AS (
         {{ this }}
     WHERE
         token_name IS NULL
+        OR LEN(REGEXP_REPLACE(token_name,'[^a-zA-Z0-9]+')) <= 0
         OR token_decimals IS NULL
         OR token_symbol IS NULL
 ),


### PR DESCRIPTION
1. Added regex to heal CTE filtering to include blank `token_name` (rather than just NULL)
2. Fixes bug on `ez_current_balances` w/incorrect decimals
3. `silver.contracts` requires FR after `silver.token_meta_reads` incremental
4. [Ticket](https://team-1612274056224.atlassian.net/browse/AN-2753)