### PR TITLE
add/missing-price-test

### DIFF
--- a/macros/tests/hour_gaps.sql
+++ b/macros/tests/hour_gaps.sql
@@ -1,0 +1,20 @@
+{% test hour_gaps(
+        model,
+        column_name
+) %}
+
+WITH gap_times AS (
+  SELECT t1.{{ column_name }} AS start_time, 
+         MIN(t2.{{ column_name }}) AS end_time
+  FROM {{ model }} t1
+  LEFT JOIN {{ model }} t2
+    ON t2.{{ column_name }} > t1.{{ column_name }}
+  GROUP BY 1
+  ORDER BY start_time DESC
+)
+SELECT *
+FROM gap_times
+WHERE end_time IS NOT NULL 
+	AND start_time::timestamp + INTERVAL '1 hour' <> end_time::timestamp
+
+{% endtest %}

--- a/models/silver/prices/silver__token_prices_all_providers_hourly.yml
+++ b/models/silver/prices/silver__token_prices_all_providers_hourly.yml
@@ -13,6 +13,10 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
+          - hour_gaps:
+              config:
+                severity: warn
+                warn_if: ">0"
       - name: TOKEN_ADDRESS
         description: Address of the token
       - name: SYMBOL


### PR DESCRIPTION
1. Adds `hour_gaps` test to determine whether there are missing prices for a given hour