### PR TITLE
AN-2810/curve-rebuild

### DIFF
--- a/models/silver/dex/silver_dex__curve_pools.sql
+++ b/models/silver/dex/silver_dex__curve_pools.sql
@@ -48,6 +48,14 @@ QUALIFY(ROW_NUMBER() OVER(PARTITION BY to_address ORDER BY block_timestamp ASC))
 function_sigs AS (
 
 SELECT
+	'0x87cb4f57' AS function_sig,
+    'base_coins' AS function_name
+UNION ALL
+SELECT
+	'0xb9947eb0' AS function_sig,
+    'underlying_coins' AS function_name
+UNION ALL
+SELECT
     '0xc6610657' AS function_sig, 
     'coins' AS function_name
 UNION ALL
@@ -86,6 +94,36 @@ JOIN function_inputs ON 1=1
     WHERE function_name = 'coins'
 ),
 
+inputs_base_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'base_coins'
+),
+
+inputs_underlying_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'underlying_coins'
+),
+
 inputs_pool_details AS (
 
 SELECT
@@ -108,6 +146,22 @@ SELECT
     function_sig,
     function_input
 FROM inputs_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_base_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_underlying_coins
 UNION ALL
 SELECT
     deployer_address,
@@ -191,12 +245,13 @@ SELECT
     contract_address,
     function_sig,
     function_name,
+    function_input,
     read_result,
     regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}')[0]AS segmented_token_address,
     _inserted_timestamp
 FROM reads_adjusted
 LEFT JOIN function_sigs USING(function_sig)
-WHERE function_name = 'coins'
+WHERE function_name IN ('coins','base_coins','underlying_coins')
     AND read_result IS NOT NULL
     
 ),
@@ -207,6 +262,7 @@ SELECT
     contract_address,
     function_sig,
     function_name,
+    function_input,
     read_result,
     regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
     _inserted_timestamp
@@ -221,6 +277,8 @@ all_pools AS (
 SELECT
     t.contract_address AS pool_address,
     CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)) AS token_address,
+    function_input AS token_id,
+    function_name AS token_type,
     MIN(CASE WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0)) END) AS pool_symbol,
     MIN(CASE WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING),
         TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
@@ -235,10 +293,10 @@ SELECT
     ) AS pool_id,
     MAX(t._inserted_timestamp) AS _inserted_timestamp
 FROM tokens t
-LEFT JOIN pool_details p ON t.contract_address = p.contract_address
+LEFT JOIN pool_details p USING(contract_address)
 WHERE token_address IS NOT NULL 
     AND token_address <> '0x0000000000000000000000000000000000000000'
-GROUP BY 1,2
+GROUP BY 1,2,3,4
 ),
 
 FINAL AS (
@@ -248,6 +306,8 @@ SELECT
         WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
         ELSE token_address
     END AS token_address,
+    token_id,
+    token_type,
     CASE 
         WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
         WHEN pool_symbol IS NULL THEN c.symbol
@@ -285,6 +345,8 @@ WHERE pool_address NOT IN (
 SELECT
     pool_address,
     token_address,
+    token_id,
+    token_type,
     pool_symbol,
     pool_name,
     pool_decimals,
@@ -295,6 +357,8 @@ UNION
 SELECT
     pool_address,
     token_address,
+    NULL AS token_id,
+    NULL AS token_type,
     pool_symbol,
     pool_name,
     pool_decimals,

--- a/models/silver/dex/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/silver_dex__curve_swaps.sql
@@ -12,7 +12,11 @@ WITH pool_meta AS (
             WHEN pool_name IS NULL AND pool_symbol IS NULL THEN CONCAT('Curve.fi Pool: ',SUBSTRING(pool_address, 1, 5),'...',SUBSTRING(pool_address, 39, 42))
             WHEN pool_name IS NULL THEN CONCAT('Curve.fi Pool: ',replace(regexp_replace(agg_symbol, '[^[:alnum:],]', '', 1, 0), ',', '-'))
         ELSE pool_name
-    END AS pool_name
+    END AS pool_name,
+    token_address,
+    pool_symbol AS symbol,
+    token_id::INTEGER AS token_id,
+    token_type::STRING AS token_type
     FROM
         {{ ref('silver_dex__curve_pools') }}
     LEFT JOIN (
@@ -23,6 +27,15 @@ WITH pool_meta AS (
         GROUP BY 1
         ) USING(pool_address)
 ),
+
+pools AS (
+
+SELECT 
+	DISTINCT pool_address,
+	pool_name
+FROM pool_meta
+),
+
 curve_base AS (
     SELECT
         block_number,
@@ -44,9 +57,9 @@ curve_base AS (
         PUBLIC.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS tokens_sold,
-        PUBLIC.udf_hex_to_int(
+        TRY_CAST(PUBLIC.udf_hex_to_int(
             segmented_data [2] :: STRING
-        ) :: INTEGER AS bought_id,
+        ) AS INTEGER) AS bought_id,
         PUBLIC.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS tokens_bought,
@@ -54,8 +67,8 @@ curve_base AS (
         _inserted_timestamp
     FROM
         {{ ref('silver__logs') }}
-        INNER JOIN pool_meta
-        ON pool_meta.pool_address = contract_address
+        INNER JOIN pools
+        ON pools.pool_address = contract_address
     WHERE
         topics [0] :: STRING IN (
             '0x8b3e96f2b889fa771c53c981b40daf005f63f637f1869f707052d15a3dd97140',
@@ -72,6 +85,21 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
+
+token_exchange AS (
+
+SELECT
+	_log_id,
+    MAX(CASE WHEN sold_id = token_id THEN token_address END) AS token_in,
+    MAX(CASE WHEN bought_id = token_id THEN token_address END) AS token_out,
+    MAX(CASE WHEN sold_id = token_id THEN symbol END) AS symbol_in,
+    MAX(CASE WHEN bought_id = token_id THEN symbol END) AS symbol_out
+FROM curve_base t
+LEFT JOIN pool_meta p ON p.pool_address = t.pool_address AND (p.token_id = t.sold_id OR p.token_id = t.bought_id)
+WHERE token_type = 'coins'
+GROUP BY 1
+),
+
 token_transfers AS (
     SELECT
         tx_hash,
@@ -122,25 +150,68 @@ to_transfers AS (
     FROM
         token_transfers
 ),
+
+ready_pool_info AS (
+
+SELECT
+	s.block_number,
+    s.block_timestamp,
+    s.tx_hash,
+    s.origin_function_signature,
+    s.origin_from_address,
+    s.origin_from_address AS tx_to,
+    s.origin_to_address,
+    event_index,
+    event_name,
+    pool_address,
+    pool_address AS contract_address,
+    pool_name,
+    sender,
+    sold_id,
+    tokens_sold,
+    COALESCE(sold.token_address,e.token_in) AS token_in,
+    e.symbol_in AS symbol_in,
+    bought_id,
+    tokens_bought,
+    COALESCE(bought.token_address,e.token_out) AS token_out,
+    e.symbol_out AS symbol_out,
+    s._log_id,
+    _inserted_timestamp
+FROM
+    curve_base s
+    LEFT JOIN token_exchange e ON s._log_id = e._log_id
+    LEFT JOIN from_transfers sold
+    ON tokens_sold = sold.amount
+    AND s.tx_hash = sold.tx_hash
+    LEFT JOIN to_transfers bought
+    ON tokens_bought = bought.amount
+    AND s.tx_hash = bought.tx_hash
+WHERE
+	tokens_sold <> 0
+qualify(ROW_NUMBER() over(PARTITION BY s._log_id
+    ORDER BY
+        _inserted_timestamp DESC)) = 1  
+),
+
 pool_info AS (
     SELECT
-        s.block_number,
-        s.block_timestamp,
-        s.tx_hash,
-        s.origin_function_signature,
-        s.origin_from_address,
-        s.origin_from_address AS tx_to,
-        s.origin_to_address,
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        tx_to,
+        origin_to_address,
         event_index,
         event_name,
         pool_address,
-        pool_address AS contract_address,
+        contract_address,
         pool_name,
         sender,
         sold_id,
         tokens_sold,
-        sold.token_address AS token_in,
-        c0.symbol symbol_in,
+        token_in,
+        COALESCE(c0.symbol,r.symbol_in) AS symbol_in,
         c0.decimals AS decimals_in,
         CASE
             WHEN decimals_in IS NOT NULL THEN tokens_sold / pow(
@@ -151,8 +222,8 @@ pool_info AS (
         END AS amount_in,
         bought_id,
         tokens_bought,
-        bought.token_address AS token_out,
-        c1.symbol AS symbol_out,
+        token_out,
+        COALESCE(c1.symbol,r.symbol_out) AS symbol_out,
         c1.decimals AS decimals_out,
         CASE
             WHEN decimals_out IS NOT NULL THEN tokens_bought / pow(
@@ -164,31 +235,21 @@ pool_info AS (
         _log_id,
         _inserted_timestamp
     FROM
-        curve_base s
-        LEFT JOIN from_transfers sold
-        ON tokens_sold = sold.amount
-        AND s.tx_hash = sold.tx_hash --  AND s.pool_address = sold.from_address
-        LEFT JOIN to_transfers bought
-        ON tokens_bought = bought.amount
-        AND s.tx_hash = bought.tx_hash -- AND s.pool_address = bought.to_address
-        LEFT JOIN {{ ref('core__dim_contracts') }}
+        ready_pool_info r
+        LEFT JOIN ETHEREUM.core.dim_contracts
         c0
-        ON c0.address = sold.token_address
-        LEFT JOIN {{ ref('core__dim_contracts') }}
+        ON c0.address = r.token_in
+        LEFT JOIN ETHEREUM.core.dim_contracts
         c1
-        ON c1.address = bought.token_address
-    WHERE
-        tokens_sold <> 0
-        AND COALESCE(symbol_out,'null') <> COALESCE(symbol_in,'null')
-    qualify(ROW_NUMBER() over(PARTITION BY _log_id
-    ORDER BY
-        _inserted_timestamp DESC)) = 1
+        ON c1.address = r.token_out
+    WHERE amount_out <> 0
 ),
+
 prices AS (
     SELECT
         HOUR,
-        LOWER(token_address) AS token_address,
-        AVG(price) AS price
+        token_address,
+        price
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -212,10 +273,8 @@ prices AS (
                     pool_info
             )
         )
-    GROUP BY
-        1,
-        2
 )
+
 SELECT
     block_number,
     block_timestamp,
@@ -267,3 +326,5 @@ FROM
         block_timestamp
     )
     AND p1.token_address = token_out
+WHERE
+    COALESCE(symbol_in,'null') <> COALESCE(symbol_out,'null')


### PR DESCRIPTION
1. Rebuilt `curve_pools` and `curve_swaps` to fill NULL `token_addresses` accurately
2. Requires FR of `silver_dex.curve_pools`+ 
3. Clears up curve related test failures