### PR TITLE
fix/snapshot-null-props

### DIFF
--- a/models/bronze/api_udf/snapshot/bronze_api__snapshot_votes.sql
+++ b/models/bronze/api_udf/snapshot/bronze_api__snapshot_votes.sql
@@ -87,3 +87,4 @@ SELECT
     vote_option,
     _inserted_timestamp
 FROM votes_final
+INNER JOIN {{ ref('bronze_api__snapshot_proposals')}} USING (proposal_id)


### PR DESCRIPTION
1. inner join snapshot_proposals on id to resolve null error
2. drop (5) rows w/existing null proposal_ids prior to merging