### PR TITLE
incremental fix

### DIFF
--- a/models/silver/balances/silver__eth_balance_diffs.sql
+++ b/models/silver/balances/silver__eth_balance_diffs.sql
@@ -81,9 +81,7 @@ update_records AS (
         all_records
         INNER JOIN min_record
         ON address = min_address
-        AND block_number < min_block qualify(ROW_NUMBER() over (PARTITION BY address
-    ORDER BY
-        block_number DESC, _inserted_timestamp DESC)) = 1
+        AND block_number < min_block
 ),
 incremental AS (
     SELECT
@@ -121,8 +119,11 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    f.*
 FROM
-    FINAL
+    FINAL f
+    INNER JOIN min_record
+    ON address = min_address
+    AND block_number >= min_block
 WHERE
     prev_bal_unadj <> current_bal_unadj


### PR DESCRIPTION
- removes qualify to include all records for an address in the order by for last balance, and then filters the old records out via and inner join on the min record for that user/token so that we don't load a ton of rows every time