### PR TITLE
AN-2448/eth-price-pivot

### DIFF
--- a/models/Sushi/sushi__dim_distributor_reward_schedule.sql
+++ b/models/Sushi/sushi__dim_distributor_reward_schedule.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'table',
+    enabled = false,
     meta={
         'database_tags':{
             'table': {

--- a/models/Sushi/sushi__dim_distributor_reward_schedule.yml
+++ b/models/Sushi/sushi__dim_distributor_reward_schedule.yml
@@ -1,4 +1,4 @@
 version: 2
 models:
   - name: sushi__dim_distributor_reward_schedule
-    description: Deprecating soon
+    # description: Deprecating soon

--- a/models/Sushi/sushi__ez_borrowing.sql
+++ b/models/Sushi/sushi__ez_borrowing.sql
@@ -5,6 +5,7 @@
   "columns": true },
   unique_key = '_log_id',
   cluster_by = ['block_timestamp::DATE'],
+  enabled = false,
   meta={
       'database_tags':{
           'table': {

--- a/models/Sushi/sushi__ez_lending.sql
+++ b/models/Sushi/sushi__ez_lending.sql
@@ -5,6 +5,7 @@
   "columns": true },
   unique_key = '_log_id',
   cluster_by = ['block_timestamp::DATE'],
+  enabled = false,
   meta={
       'database_tags':{
           'table': {

--- a/models/Sushi/sushi__ez_swaps.sql
+++ b/models/Sushi/sushi__ez_swaps.sql
@@ -2,6 +2,7 @@
   materialized = 'view',
   persist_docs ={ "relation": true,
   "columns": true },
+  enabled = false,
   meta={
       'database_tags':{
           'table': {

--- a/models/Sushi/sushi__ez_swaps.yml
+++ b/models/Sushi/sushi__ez_swaps.yml
@@ -1,48 +1,48 @@
 version: 2
 models:
   - name: sushi__ez_swaps
-    description: Deprecating soon
+    # description: Deprecating soon
 
-    columns:
-      - name: BLOCK_NUMBER
-        description: '{{ doc("eth_block_number") }}'
-      - name: BLOCK_TIMESTAMP
-        description: '{{ doc("eth_block_timestamp") }}'
-      - name: TX_HASH
-        description: '{{ doc("eth_logs_tx_hash") }}'
-      - name: CONTRACT_ADDRESS
-        description: '{{ doc("eth_logs_contract_address") }}'
-      - name: EVENT_NAME
-        description: '{{ doc("eth_event_name") }}'
-      - name: AMOUNT_IN
-        description: '{{ doc("eth_dex_swaps_amount_in") }}'
-      - name: AMOUNT_OUT
-        description: '{{ doc("eth_dex_swaps_amount_out") }}'
-      - name: AMOUNT_IN_USD
-        description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
-      - name: AMOUNT_OUT_USD
-        description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
-      - name: TOKEN_IN
-        description: '{{ doc("eth_dex_swaps_token_in") }}'
-      - name: TOKEN_OUT
-        description: '{{ doc("eth_dex_swaps_token_out") }}'
-      - name: SYMBOL_IN
-        description: '{{ doc("eth_dex_swaps_symbol_in") }}'
-      - name: SYMBOL_OUT
-        description: '{{ doc("eth_dex_swaps_symbol_out") }}'
-      - name: SENDER
-        description: '{{ doc("eth_dex_swaps_sender") }}'
-      - name: TX_TO
-        description: '{{ doc("eth_dex_swaps_tx_to") }}'
-      - name: PLATFORM
-        description: '{{ doc("eth_dex_platform") }}'
-      - name: EVENT_INDEX
-        description: '{{ doc("eth_event_index") }}'
-      - name: ORIGIN_FUNCTION_SIGNATURE
-        description: '{{ doc("eth_nft_origin_sig") }}'
-      - name: ORIGIN_FROM_ADDRESS
-        description: '{{ doc("eth_origin_from") }}'
-      - name: ORIGIN_TO_ADDRESS
-        description: '{{ doc("eth_origin_to") }}'
+    # columns:
+    #   - name: BLOCK_NUMBER
+    #     description: '{{ doc("eth_block_number") }}'
+    #   - name: BLOCK_TIMESTAMP
+    #     description: '{{ doc("eth_block_timestamp") }}'
+    #   - name: TX_HASH
+    #     description: '{{ doc("eth_logs_tx_hash") }}'
+    #   - name: CONTRACT_ADDRESS
+    #     description: '{{ doc("eth_logs_contract_address") }}'
+    #   - name: EVENT_NAME
+    #     description: '{{ doc("eth_event_name") }}'
+    #   - name: AMOUNT_IN
+    #     description: '{{ doc("eth_dex_swaps_amount_in") }}'
+    #   - name: AMOUNT_OUT
+    #     description: '{{ doc("eth_dex_swaps_amount_out") }}'
+    #   - name: AMOUNT_IN_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
+    #   - name: AMOUNT_OUT_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
+    #   - name: TOKEN_IN
+    #     description: '{{ doc("eth_dex_swaps_token_in") }}'
+    #   - name: TOKEN_OUT
+    #     description: '{{ doc("eth_dex_swaps_token_out") }}'
+    #   - name: SYMBOL_IN
+    #     description: '{{ doc("eth_dex_swaps_symbol_in") }}'
+    #   - name: SYMBOL_OUT
+    #     description: '{{ doc("eth_dex_swaps_symbol_out") }}'
+    #   - name: SENDER
+    #     description: '{{ doc("eth_dex_swaps_sender") }}'
+    #   - name: TX_TO
+    #     description: '{{ doc("eth_dex_swaps_tx_to") }}'
+    #   - name: PLATFORM
+    #     description: '{{ doc("eth_dex_platform") }}'
+    #   - name: EVENT_INDEX
+    #     description: '{{ doc("eth_event_index") }}'
+    #   - name: ORIGIN_FUNCTION_SIGNATURE
+    #     description: '{{ doc("eth_nft_origin_sig") }}'
+    #   - name: ORIGIN_FROM_ADDRESS
+    #     description: '{{ doc("eth_origin_from") }}'
+    #   - name: ORIGIN_TO_ADDRESS
+    #     description: '{{ doc("eth_origin_to") }}'
 
 

--- a/models/gold/core__ez_eth_transfers.sql
+++ b/models/gold/core__ez_eth_transfers.sql
@@ -43,9 +43,9 @@ AND _inserted_timestamp >= (
 eth_price AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price
+        price AS eth_price
     FROM
-        {{ ref('silver__token_prices_all_providers_hourly') }}
+        {{ ref('core__fact_hourly_token_prices') }}
     WHERE
         token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
         AND HOUR :: DATE IN (
@@ -54,8 +54,6 @@ eth_price AS (
             FROM
                 eth_base
         )
-    GROUP BY
-        HOUR
 ),
 tx_table AS (
     SELECT

--- a/models/gold/core__fact_hourly_token_prices.sql
+++ b/models/gold/core__fact_hourly_token_prices.sql
@@ -3,13 +3,15 @@
 ) }}
 
 SELECT
-    HOUR,
-    lower(token_address) as token_address,
+    hour,
+    token_address,
     symbol,
     decimals,
     price,
     is_imputed
 FROM
-    {{ ref(
-        'silver__token_prices_all_providers_hourly'
+    {{ source(
+        'crosschain',
+        'ez_hourly_prices'
     ) }}
+WHERE blockchain = 'ethereum'

--- a/models/gold/core__fact_hourly_token_prices.yml
+++ b/models/gold/core__fact_hourly_token_prices.yml
@@ -6,8 +6,12 @@ models:
     columns:
       - name: HOUR
         description: '{{ doc("eth_prices_hour") }}'   
+        tests:
+          - not_null
       - name: TOKEN_ADDRESS
         description: '{{ doc("eth_prices_address") }}' 
+        tests:
+          - not_null
       - name: SYMBOL
         description: '{{ doc("eth_prices_symbol") }}' 
       - name: DECIMALS

--- a/models/silver/nft/silver_nft__blur_decoded_sales.sql
+++ b/models/silver/nft/silver_nft__blur_decoded_sales.sql
@@ -162,7 +162,7 @@ AND _inserted_timestamp >= (
 eth_price AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price_hourly
+        price AS eth_price_hourly
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -174,8 +174,6 @@ eth_price AS (
             FROM
                 tx_data
         )
-    GROUP BY
-        HOUR
 ),
 base_combined AS (
     SELECT

--- a/models/silver/nft/silver_nft__cryptopunk_sales.sql
+++ b/models/silver/nft/silver_nft__cryptopunk_sales.sql
@@ -120,7 +120,7 @@ nft_transactions AS (
         0 AS platform_fee,
         0 AS creator_fee,
         _inserted_timestamp,
-        input_data 
+        input_data
     FROM
         {{ ref('silver__transactions') }}
     WHERE
@@ -145,13 +145,11 @@ AND _inserted_timestamp >= (
 eth_prices AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price
+        (price) AS eth_price
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
         token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-    GROUP BY
-        HOUR
 ),
 FINAL AS (
     SELECT
@@ -198,7 +196,7 @@ FINAL AS (
         tx_fee,
         punk_sales._log_id,
         punk_sales._inserted_timestamp,
-        input_data 
+        input_data
     FROM
         punk_sales
         LEFT JOIN nft_transfers

--- a/models/silver/nft/silver_nft__looksrare_decoded_sales.sql
+++ b/models/silver/nft/silver_nft__looksrare_decoded_sales.sql
@@ -228,7 +228,7 @@ all_prices AS (
         symbol,
         token_address AS currency_address,
         decimals,
-        AVG(price) AS hourly_prices
+        (price) AS hourly_prices
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -247,18 +247,13 @@ all_prices AS (
                 tx_data
         )
         AND HOUR :: DATE >= '2021-12-20'
-    GROUP BY
-        HOUR,
-        decimals,
-        symbol,
-        token_address
     UNION ALL
     SELECT
         HOUR,
         'ETH' AS symbol,
         'ETH' AS currency_address,
         decimals,
-        AVG(price) AS hourly_prices
+        (price) AS hourly_prices
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -270,16 +265,11 @@ all_prices AS (
                 tx_data
         )
         AND HOUR :: DATE >= '2021-12-20'
-    GROUP BY
-        HOUR,
-        decimals,
-        symbol,
-        currency_address
 ),
 eth_price AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price_hourly
+        (price) AS eth_price_hourly
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -291,8 +281,6 @@ eth_price AS (
             FROM
                 tx_data
         )
-    GROUP BY
-        HOUR
 ),
 nft_transfers AS (
     SELECT

--- a/models/silver/nft/silver_nft__looksrare_decoded_sales.sql
+++ b/models/silver/nft/silver_nft__looksrare_decoded_sales.sql
@@ -225,19 +225,9 @@ AND _inserted_timestamp >= (
 all_prices AS (
     SELECT
         HOUR,
-        CASE
-            WHEN symbol IS NULL
-            AND token_address IS NULL THEN 'ETH'
-            ELSE symbol
-        END AS symbol,
-        CASE
-            WHEN LOWER(token_address) IS NULL THEN 'ETH'
-            ELSE LOWER(token_address)
-        END AS currency_address,
-        CASE
-            WHEN currency_address = 'ETH' THEN '18'
-            ELSE decimals
-        END AS decimals,
+        symbol,
+        token_address AS currency_address,
+        decimals,
         AVG(price) AS hourly_prices
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
@@ -248,10 +238,6 @@ all_prices AS (
                     DISTINCT currency_address
                 FROM
                     base_decoded_combined
-            )
-            OR (
-                token_address IS NULL
-                AND symbol IS NULL
             )
         )
         AND HOUR :: DATE IN (
@@ -266,6 +252,29 @@ all_prices AS (
         decimals,
         symbol,
         token_address
+    UNION ALL
+    SELECT
+        HOUR,
+        'ETH' AS symbol,
+        'ETH' AS currency_address,
+        decimals,
+        AVG(price) AS hourly_prices
+    FROM
+        {{ ref('core__fact_hourly_token_prices') }}
+    WHERE
+        token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        AND HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                tx_data
+        )
+        AND HOUR :: DATE >= '2021-12-20'
+    GROUP BY
+        HOUR,
+        decimals,
+        symbol,
+        currency_address
 ),
 eth_price AS (
     SELECT

--- a/models/silver/nft/silver_nft__nftx_decoded_sales.sql
+++ b/models/silver/nft/silver_nft__nftx_decoded_sales.sql
@@ -772,20 +772,10 @@ AND _inserted_timestamp >= (
 all_prices AS (
     SELECT
         HOUR,
-        CASE
-            WHEN symbol IS NULL
-            AND token_address IS NULL THEN 'ETH'
-            ELSE symbol
-        END AS symbol,
-        CASE
-            WHEN LOWER(token_address) IS NULL THEN 'ETH'
-            ELSE LOWER(token_address)
-        END AS currency_address,
-        CASE
-            WHEN currency_address = 'ETH' THEN '18'
-            ELSE decimals
-        END AS decimals,
-        AVG(price) AS hourly_prices
+        symbol,
+        token_address AS currency_address,
+        decimals,
+        (price) AS hourly_prices
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -796,10 +786,6 @@ all_prices AS (
                 FROM
                     final_base
             )
-            OR (
-                token_address IS NULL
-                AND symbol IS NULL
-            )
         )
         AND HOUR :: DATE IN (
             SELECT
@@ -808,16 +794,29 @@ all_prices AS (
                 tx_data
         )
         AND HOUR :: DATE >= '2021-06-01'
-    GROUP BY
+    UNION ALL
+    SELECT
         HOUR,
+        'ETH' AS symbol,
+        'ETH' AS currency_address,
         decimals,
-        symbol,
-        token_address
+        (price) AS hourly_prices
+    FROM
+        {{ ref('core__fact_hourly_token_prices') }}
+    WHERE
+        token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        AND HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                tx_data
+        )
+        AND HOUR :: DATE >= '2021-06-01'
 ),
 eth_price AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price_hourly
+        (price) AS eth_price_hourly
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -829,8 +828,6 @@ eth_price AS (
             FROM
                 tx_data
         )
-    GROUP BY
-        HOUR
 ),
 final_base_txs AS (
     SELECT

--- a/models/silver/nft/silver_nft__sudoswap_sales.sql
+++ b/models/silver/nft/silver_nft__sudoswap_sales.sql
@@ -4,17 +4,18 @@
     cluster_by = ['block_timestamp::DATE']
 ) }}
 
-WITH sudoswap_tx as (
-    SELECT  
+WITH sudoswap_tx AS (
+
+    SELECT
         block_timestamp,
-        tx_hash 
-    FROM 
+        tx_hash
+    FROM
         {{ ref('silver__logs') }}
-    WHERE 
+    WHERE
         block_timestamp >= '2022-01-01'
-        AND topics[0] in (
-             '0xf06180fdbe95e5193df4dcd1352726b1f04cb58599ce58552cc952447af2ffbb'
-             ,'0xbc479dfc6cb9c1a9d880f987ee4b30fa43dd7f06aec121db685b67d587c93c93'
+        AND topics [0] IN (
+            '0xf06180fdbe95e5193df4dcd1352726b1f04cb58599ce58552cc952447af2ffbb',
+            '0xbc479dfc6cb9c1a9d880f987ee4b30fa43dd7f06aec121db685b67d587c93c93'
         )
 
 {% if is_incremental() %}
@@ -28,24 +29,25 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
-
-traces_all_sudo as (
-    SELECT 
+traces_all_sudo AS (
+    SELECT
         tx_hash,
-        from_address, 
-        to_address, 
-        eth_value 
+        from_address,
+        to_address,
+        eth_value
     FROM
         {{ ref('silver__traces') }}
-    WHERE  block_timestamp >= '2022-01-01'
+    WHERE
+        block_timestamp >= '2022-01-01'
         AND block_number > 14000000
         AND identifier <> 'CALL_ORIGIN'
-        AND ETH_VALUE > 1e-18
+        AND eth_value > 1e -18
         AND tx_status = 'SUCCESS'
-        AND tx_hash in (
-            SELECT 
-            tx_hash 
-            from sudoswap_tx
+        AND tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                sudoswap_tx
         )
 
 {% if is_incremental() %}
@@ -59,10 +61,8 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
-
 -- start by finding sales in traces
 sale_data1 AS (
-
     SELECT
         tx_hash,
         from_address,
@@ -88,12 +88,13 @@ sale_data1 AS (
         )
         AND TYPE = 'CALL'
         AND identifier <> 'CALL_ORIGIN'
-        AND eth_value > 1e-18
+        AND eth_value > 1e -18
         AND tx_status = 'SUCCESS'
-        AND tx_hash in (
-            SELECT 
-                tx_hash 
-            FROM sudoswap_tx
+        AND tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                sudoswap_tx
         )
 
 {% if is_incremental() %}
@@ -192,10 +193,11 @@ count_details AS (
             '0x7ca542ac',
             '0x097cc63d'
         )
-        AND tx_hash in (
-            SELECT 
-                tx_hash 
-            FROM sudoswap_tx
+        AND tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                sudoswap_tx
         )
 
 {% if is_incremental() %}
@@ -354,12 +356,13 @@ sale_data AS (
         ) AS row_no
     FROM
         union_records
-
-    WHERE tx_hash in (
-        SELECT 
-            tx_hash 
-        FROM sudoswap_tx
-    )
+    WHERE
+        tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                sudoswap_tx
+        )
 ),
 dedup_counts AS (
     SELECT
@@ -487,10 +490,10 @@ sudo_events AS (
             FROM
                 {{ ref('silver__logs') }}
             WHERE
-                topics[0] in (
-             '0xf06180fdbe95e5193df4dcd1352726b1f04cb58599ce58552cc952447af2ffbb'
-             ,'0xbc479dfc6cb9c1a9d880f987ee4b30fa43dd7f06aec121db685b67d587c93c93'
-        )
+                topics [0] IN (
+                    '0xf06180fdbe95e5193df4dcd1352726b1f04cb58599ce58552cc952447af2ffbb',
+                    '0xbc479dfc6cb9c1a9d880f987ee4b30fa43dd7f06aec121db685b67d587c93c93'
+                )
                 AND tx_hash IN (
                     SELECT
                         DISTINCT tx_hash
@@ -564,11 +567,12 @@ nft_sales AS (
                     FROM
                         sale_data
                 )
-            AND from_address::string in (
-                SELECT 
-                    to_address::string
-                FROM traces_all_sudo
-            )
+                AND from_address :: STRING IN (
+                    SELECT
+                        to_address :: STRING
+                    FROM
+                        traces_all_sudo
+                )
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -605,12 +609,12 @@ swap_final AS (
         ON nft_sales.tx_hash = amounts_and_counts.tx_hash
         AND agg_id BETWEEN agg_id_min
         AND agg_id_max
-
-    WHERE 
-        nft_sales.tx_hash in (
-            select 
-            tx_hash 
-            from sudoswap_tx
+    WHERE
+        nft_sales.tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                sudoswap_tx
         )
 ),
 token_transfers AS (
@@ -658,7 +662,7 @@ usd_prices AS (
     SELECT
         HOUR,
         token_address,
-        AVG(price) AS token_price
+        (price) AS token_price
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
@@ -673,17 +677,12 @@ usd_prices AS (
                 )
             )
         )
-    AND HOUR :: DATE IN (
+        AND HOUR :: DATE IN (
             SELECT
                 DISTINCT block_timestamp :: DATE
             FROM
                 sudoswap_tx
         )
-
-    GROUP BY
-        HOUR,
-        token_address
-
 ),
 eth_prices AS (
     SELECT
@@ -747,7 +746,7 @@ SELECT
     ) AS tx_fee_usd,
     _log_id,
     _inserted_timestamp,
-    sudo_interactions.input_data 
+    sudo_interactions.input_data
 FROM
     swap_final
     LEFT JOIN sudo_interactions

--- a/models/silver/prices/silver__token_prices_all_providers_hourly.sql
+++ b/models/silver/prices/silver__token_prices_all_providers_hourly.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
-    enabled = 'false',
+    enabled = false,
     cluster_by = ['hour::DATE'],
 ) }}
 

--- a/models/silver/prices/silver__token_prices_all_providers_hourly.sql
+++ b/models/silver/prices/silver__token_prices_all_providers_hourly.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
+    enabled = 'false',
     cluster_by = ['hour::DATE'],
 ) }}
 

--- a/models/silver/prices/silver__token_prices_all_providers_hourly.yml
+++ b/models/silver/prices/silver__token_prices_all_providers_hourly.yml
@@ -1,39 +1,39 @@
 version: 2
 models:
   - name: silver__token_prices_all_providers_hourly
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - HOUR
-            - TOKEN_ADDRESS
-    columns:
-      - name: HOUR
-        description: Hour that the price was recorded at
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
-          - hour_gaps:
-              config:
-                severity: warn
-                warn_if: ">0"
-      - name: TOKEN_ADDRESS
-        description: Address of the token
-      - name: SYMBOL
-        description: Symbol of the token
-      - name: DECIMALS
-        description: The number of decimals for token contract
-      - name: PRICE
-        description: Closing price of the recorded hour in USD
-        tests: 
-          - not_null
-      - name: IS_IMPUTED
-        description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
-        tests: 
-          - not_null
-      - name: _UNIQUE_KEY
-        description: Concatenation of multiple columns used for incremental merge
-      - name: _INSERTED_TIMESTAMP
-        description: Latest timestamp that the record was inserted at
-        tests:
-          - not_null
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - HOUR
+    #         - TOKEN_ADDRESS
+    # columns:
+    #   - name: HOUR
+    #     description: Hour that the price was recorded at
+    #     tests:
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 1
+    #       - hour_gaps:
+    #           config:
+    #             severity: warn
+    #             warn_if: ">0"
+    #   - name: TOKEN_ADDRESS
+    #     description: Address of the token
+    #   - name: SYMBOL
+    #     description: Symbol of the token
+    #   - name: DECIMALS
+    #     description: The number of decimals for token contract
+    #   - name: PRICE
+    #     description: Closing price of the recorded hour in USD
+    #     tests: 
+    #       - not_null
+    #   - name: IS_IMPUTED
+    #     description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+    #     tests: 
+    #       - not_null
+    #   - name: _UNIQUE_KEY
+    #     description: Concatenation of multiple columns used for incremental merge
+    #   - name: _INSERTED_TIMESTAMP
+    #     description: Latest timestamp that the record was inserted at
+    #     tests:
+    #       - not_null

--- a/models/silver/prices/silver__token_prices_coin_gecko_hourly.sql
+++ b/models/silver/prices/silver__token_prices_coin_gecko_hourly.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
+    enabled = false,
     cluster_by = ['recorded_hour::DATE'],
 ) }}
 

--- a/models/silver/prices/silver__token_prices_coin_gecko_hourly.yml
+++ b/models/silver/prices/silver__token_prices_coin_gecko_hourly.yml
@@ -1,36 +1,36 @@
 version: 2
 models:
   - name: silver__token_prices_coin_gecko_hourly
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - RECORDED_HOUR
-            - TOKEN_ADDRESS
-    columns:
-      - name: RECORDED_HOUR
-        description: Hour that the price was recorded at
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
-      - name: TOKEN_ADDRESS
-        description: Address of the token
-        tests:
-          - token_address_match:
-              config:
-                severity: warn
-                warn_if: ">100"
-      - name: CLOSE
-        description: Closing price of the recorded hour in USD
-        tests: 
-          - not_null
-      - name: IMPUTED
-        description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
-        tests: 
-          - not_null
-      - name: _UNIQUE_KEY
-        description: Concatenation of multiple columns used for incremental merge
-      - name: _INSERTED_TIMESTAMP
-        description: Latest timestamp that the record was inserted at
-        tests:
-          - not_null
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - RECORDED_HOUR
+    #         - TOKEN_ADDRESS
+    # columns:
+    #   - name: RECORDED_HOUR
+    #     description: Hour that the price was recorded at
+    #     tests:
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 1
+    #   - name: TOKEN_ADDRESS
+    #     description: Address of the token
+    #     tests:
+    #       - token_address_match:
+    #           config:
+    #             severity: warn
+    #             warn_if: ">100"
+    #   - name: CLOSE
+    #     description: Closing price of the recorded hour in USD
+    #     tests: 
+    #       - not_null
+    #   - name: IMPUTED
+    #     description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+    #     tests: 
+    #       - not_null
+    #   - name: _UNIQUE_KEY
+    #     description: Concatenation of multiple columns used for incremental merge
+    #   - name: _INSERTED_TIMESTAMP
+    #     description: Latest timestamp that the record was inserted at
+    #     tests:
+    #       - not_null

--- a/models/silver/prices/silver__token_prices_coin_market_cap_hourly.sql
+++ b/models/silver/prices/silver__token_prices_coin_market_cap_hourly.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
+    enabled = false,
     cluster_by = ['recorded_hour::DATE'],
 ) }}
 

--- a/models/silver/prices/silver__token_prices_coin_market_cap_hourly.yml
+++ b/models/silver/prices/silver__token_prices_coin_market_cap_hourly.yml
@@ -1,36 +1,36 @@
 version: 2
 models:
   - name: silver__token_prices_coin_market_cap_hourly
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - RECORDED_HOUR
-            - TOKEN_ADDRESS
-    columns:
-      - name: RECORDED_HOUR
-        description: Hour that the price was recorded at
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
-      - name: TOKEN_ADDRESS
-        description: Address of the token
-        tests:
-          - token_address_match:
-              config:
-                severity: warn
-                warn_if: ">100"
-      - name: CLOSE
-        description: Closing price of the recorded hour in USD
-        tests: 
-          - not_null
-      - name: IMPUTED
-        description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
-        tests: 
-          - not_null
-      - name: _UNIQUE_KEY
-        description: Concatenation of multiple columns used for incremental merge
-      - name: _INSERTED_TIMESTAMP
-        description: Latest timestamp that the record was inserted at
-        tests:
-          - not_null
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - RECORDED_HOUR
+    #         - TOKEN_ADDRESS
+    # columns:
+    #   - name: RECORDED_HOUR
+    #     description: Hour that the price was recorded at
+    #     tests:
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 1
+    #   - name: TOKEN_ADDRESS
+    #     description: Address of the token
+    #     tests:
+    #       - token_address_match:
+    #           config:
+    #             severity: warn
+    #             warn_if: ">100"
+    #   - name: CLOSE
+    #     description: Closing price of the recorded hour in USD
+    #     tests: 
+    #       - not_null
+    #   - name: IMPUTED
+    #     description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+    #     tests: 
+    #       - not_null
+    #   - name: _UNIQUE_KEY
+    #     description: Concatenation of multiple columns used for incremental merge
+    #   - name: _INSERTED_TIMESTAMP
+    #     description: Latest timestamp that the record was inserted at
+    #     tests:
+    #       - not_null

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -21,6 +21,7 @@ sources:
     tables:
       - name: address_labels
       - name: dim_date_hours
+      - name: ez_hourly_prices
   - name: flipside_silver_ethereum
     database: flipside_prod_db
     schema: silver_ethereum


### PR DESCRIPTION
1. Changed source for `core.fact_hourly_token_prices` to `crosschain.ez_hourly_prices`
2. Replaced any references to `silver` prices with the `core` view and disabled it
3. Disabled sushi models as part of deprecation process