### PR TITLE
transferbatch logic

### DIFF
--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    unique_key = 'token_log_id',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE', 'contract_address'],
     tags = ['core']
 ) }}
@@ -27,10 +27,13 @@ WITH base AS (
                 topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
                 AND DATA = '0x'
                 AND topics [3] IS NOT NULL
-            ) --erc721s
+            ) --erc721s TransferSingle event
             OR (
                 topics [0] :: STRING = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
             ) --erc1155s
+            OR (
+                topics [0] :: STRING = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb'
+            ) --erc1155s TransferBatch event
             OR (
                 topics [0] :: STRING IN (
                     '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3',
@@ -114,6 +117,132 @@ transfer_singles AS (
         base
     WHERE
         topics [0] :: STRING = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+),
+transfer_batch_raw AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS operator_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS to_address,
+        contract_address,
+        ethereum.public.udf_hex_to_int(
+            segmented_data [2] :: STRING
+        ) :: STRING AS tokenid_length,
+        tokenid_length AS quantity_length,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb'
+),
+flattened AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        _log_id,
+        _inserted_timestamp,
+        tx_hash,
+        event_index,
+        operator_address,
+        from_address,
+        to_address,
+        contract_address,
+        INDEX,
+        VALUE,
+        tokenid_length,
+        quantity_length,
+        '2' + tokenid_length AS tokenid_indextag,
+        '4' + tokenid_length AS quantity_indextag_start,
+        '4' + tokenid_length + tokenid_length AS quantity_indextag_end,
+        CASE
+            WHEN INDEX BETWEEN 3
+            AND (
+                tokenid_indextag
+            ) THEN 'tokenid'
+            WHEN INDEX BETWEEN (
+                quantity_indextag_start
+            )
+            AND (
+                quantity_indextag_end
+            ) THEN 'quantity'
+            ELSE NULL
+        END AS label
+    FROM
+        transfer_batch_raw,
+        LATERAL FLATTEN (
+            input => segmented_data
+        )
+),
+tokenid_list AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        _log_id,
+        _inserted_timestamp,
+        tx_hash,
+        event_index,
+        operator_address,
+        from_address,
+        to_address,
+        contract_address,
+        ethereum.public.udf_hex_to_int(
+            VALUE :: STRING
+        ) AS tokenId,
+        ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            event_index
+            ORDER BY
+                INDEX ASC
+        ) AS tokenid_order
+    FROM
+        flattened
+    WHERE
+        label = 'tokenid'
+),
+quantity_list AS (
+    SELECT
+        tx_hash,
+        event_index,
+        ethereum.public.udf_hex_to_int(
+            VALUE :: STRING
+        ) AS quantity,
+        ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            event_index
+            ORDER BY
+                INDEX ASC
+        ) AS quantity_order
+    FROM
+        flattened
+    WHERE
+        label = 'quantity'
+),
+transfer_batch_final AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        _log_id,
+        _inserted_timestamp,
+        t.tx_hash,
+        t.event_index,
+        operator_address,
+        from_address,
+        to_address,
+        contract_address,
+        t.tokenId AS token_id,
+        q.quantity AS erc1155_value,
+        tokenid_order AS intra_event_index
+    FROM
+        tokenid_list t
+        INNER JOIN quantity_list q
+        ON t.tx_hash = q.tx_hash
+        AND t.event_index = q.event_index
+        AND t.tokenid_order = q.quantity_order
 ),
 punks_bought AS (
     SELECT
@@ -208,7 +337,14 @@ all_transfers AS (
         token_id,
         erc1155_value,
         _inserted_timestamp,
-        event_index
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id
+        ) AS token_log_id
     FROM
         erc721s
     UNION ALL
@@ -223,7 +359,14 @@ all_transfers AS (
         token_id,
         erc1155_value,
         _inserted_timestamp,
-        event_index
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id
+        ) AS token_log_id
     FROM
         transfer_singles
     UNION ALL
@@ -238,7 +381,38 @@ all_transfers AS (
         token_id,
         erc1155_value,
         _inserted_timestamp,
-        event_index
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id,
+            '-',
+            intra_event_index
+        ) AS token_log_id
+    FROM
+        transfer_batch_final
+    UNION ALL
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id
+        ) AS token_log_id
     FROM
         punks_bought
     UNION ALL
@@ -253,7 +427,14 @@ all_transfers AS (
         token_id,
         erc1155_value,
         _inserted_timestamp,
-        event_index
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id
+        ) AS token_log_id
     FROM
         punks_transfer
     UNION ALL
@@ -268,7 +449,14 @@ all_transfers AS (
         token_id,
         erc1155_value,
         _inserted_timestamp,
-        event_index
+        event_index,
+        CONCAT(
+            contract_address,
+            '-',
+            token_id,
+            '-',
+            _log_id
+        ) AS token_log_id
     FROM
         legacy_tokens
 ),
@@ -287,6 +475,7 @@ final_base AS (
             WHEN from_address = '0x0000000000000000000000000000000000000000' THEN 'mint'
             ELSE 'other'
         END AS event_type,
+        token_log_id,
         _log_id,
         _inserted_timestamp
     FROM
@@ -326,6 +515,7 @@ SELECT
     m.token_metadata,
     erc1155_value,
     event_type,
+    token_log_id,
     _log_id,
     _inserted_timestamp
 FROM
@@ -335,7 +525,7 @@ FROM
     LEFT JOIN metadata m
     ON final_base.contract_address = m.project_address
     AND final_base.tokenId = m.token_id qualify ROW_NUMBER() over (
-        PARTITION BY _log_id
+        PARTITION BY token_log_id
         ORDER BY
             _inserted_timestamp DESC
     ) = 1

--- a/models/silver/silver__nft_transfers.yml
+++ b/models/silver/silver__nft_transfers.yml
@@ -4,7 +4,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - TOKEN_LOG_ID
+            - _LOG_ID
     columns:
       - name: BLOCK_NUMBER
         tests:

--- a/models/silver/silver__nft_transfers.yml
+++ b/models/silver/silver__nft_transfers.yml
@@ -4,7 +4,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - _LOG_ID
+            - TOKEN_LOG_ID
     columns:
       - name: BLOCK_NUMBER
         tests:


### PR DESCRIPTION
Adding ERC1155's TransferBatch logic in nft transfers table 
- each event can contain transfers of multiple tokenIds + a quantity value 
- since multiple tokenIds can appear in the same event (and the same tokenId can appear twice in the same event too), I'm introducing a new token_log_id column to qualify 