### PR TITLE
An 3222/refine test

### DIFF
--- a/macros/tests/tx_gaps.sql
+++ b/macros/tests/tx_gaps.sql
@@ -29,7 +29,13 @@ FROM
     LEFT JOIN model_name
     ON block_base.block_number = model_name.block_number
 WHERE
-    tx_count <> model_tx_count
+    (
+        tx_count <> model_tx_count
+    )
+    OR (
+        model_tx_count IS NULL
+        AND tx_count <> 0
+    )
 {% endmacro %}
 
 {% macro recent_tx_gaps(
@@ -63,5 +69,11 @@ FROM
     LEFT JOIN model_name
     ON block_base.block_number = model_name.block_number
 WHERE
-    tx_count <> model_tx_count
+    (
+        tx_count <> model_tx_count
+    )
+    OR (
+        model_tx_count IS NULL
+        AND tx_count <> 0
+    )
 {% endmacro %}

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -83,14 +83,12 @@ new_records AS (
     FROM
         flat_logs l
         LEFT OUTER JOIN {{ ref('silver__transactions') }}
-        txs USING (
-            block_number,
-            tx_hash
-        )
+        txs
+        ON l.block_number = txs.block_number
+        AND l.tx_hash = txs.tx_hash
 
 {% if is_incremental() %}
-WHERE
-    txs._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND txs._INSERTED_TIMESTAMP >= '{{ lookback() }}'
 {% endif %}
 )
 

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -257,8 +257,7 @@ flattened_traces AS (
                 AND f.block_number = t.block_number
 
 {% if is_incremental() %}
-WHERE
-    t._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND t._INSERTED_TIMESTAMP >= '{{ lookback() }}'
 {% endif %}
 )
 

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -118,14 +118,13 @@ new_records AS (
         r
         ON A.block_number = r.block_number
         AND A.data :hash :: STRING = r.tx_hash
-        LEFT OUTER JOIN {{ ref('silver__blocks') }}
-        b
-        ON A.block_number = b.block_number
 
 {% if is_incremental() %}
-WHERE
-    r._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND r._INSERTED_TIMESTAMP >= '{{ lookback() }}'
 {% endif %}
+LEFT OUTER JOIN {{ ref('silver__blocks') }}
+b
+ON A.block_number = b.block_number
 )
 
 {% if is_incremental() %},


### PR DESCRIPTION
- refines tx_gap macro test
- moves lookback to join key instead of where
- handles tickets AN-3333 and AN-3332