### PR TITLE
AN-3336/snapshot-vote-cadence

### DIFF
--- a/models/bronze/api_udf/snapshot/bronze_api__snapshot_votes.sql
+++ b/models/bronze/api_udf/snapshot/bronze_api__snapshot_votes.sql
@@ -54,7 +54,7 @@ WITH RECURSIVE votes_request AS (
             {% endif %}
             ) max_time
         ) ON 1=1
-    WHERE r.total_retrieved <= 4000
+    WHERE r.total_retrieved <= 5000
 ),
 
 votes_final AS (

--- a/models/silver/silver__snapshot.yml
+++ b/models/silver/silver__snapshot.yml
@@ -30,9 +30,6 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 3
       - name: CHOICES
         tests:
           - not_null
@@ -57,3 +54,8 @@ models:
       - name: PROPOSAL_END_TIME
         tests:
           - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1


### PR DESCRIPTION
1. increased limit on # of records per run
2. moved recency test to _inserted_timestamp