### PR TITLE
fix/to-addr-nulls

### DIFF
--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -90,7 +90,7 @@ new_records AS (
 {% if is_incremental() %}
 AND txs._INSERTED_TIMESTAMP >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) :: DATE - 1
     FROM
         {{ this }}
 )

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -88,7 +88,12 @@ new_records AS (
         AND l.tx_hash = txs.tx_hash
 
 {% if is_incremental() %}
-AND txs._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND txs._INSERTED_TIMESTAMP >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 3
+    FROM
+        {{ this }}
+)
 {% endif %}
 )
 

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -257,7 +257,12 @@ flattened_traces AS (
                 AND f.block_number = t.block_number
 
 {% if is_incremental() %}
-AND t._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND t._INSERTED_TIMESTAMP >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 3
+    FROM
+        {{ this }}
+)
 {% endif %}
 )
 

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -259,7 +259,7 @@ flattened_traces AS (
 {% if is_incremental() %}
 AND t._INSERTED_TIMESTAMP >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) :: DATE - 1
     FROM
         {{ this }}
 )

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -122,7 +122,7 @@ new_records AS (
 {% if is_incremental() %}
 AND r._INSERTED_TIMESTAMP >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) :: DATE - 1
     FROM
         {{ this }}
 )

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -120,7 +120,12 @@ new_records AS (
         AND A.data :hash :: STRING = r.tx_hash
 
 {% if is_incremental() %}
-AND r._INSERTED_TIMESTAMP >= '{{ lookback() }}'
+AND r._INSERTED_TIMESTAMP >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 3
+    FROM
+        {{ this }}
+)
 {% endif %}
 LEFT OUTER JOIN {{ ref('silver__blocks') }}
 b


### PR DESCRIPTION
1. Changes join key from macro -> subquery to resolve issues with null columns