### PR TITLE
fix/op-batch-subs

### DIFF
--- a/models/silver/optimism/silver__optimism_state_hashes.yml
+++ b/models/silver/optimism/silver__optimism_state_hashes.yml
@@ -16,9 +16,6 @@ models:
       - name: STATE_BLOCK_TIMESTAMP
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_LTZ
@@ -71,9 +68,6 @@ models:
       - name: _INSERTED_TIMESTAMP
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_LTZ

--- a/models/silver/optimism/silver__optimism_submission_hashes.yml
+++ b/models/silver/optimism/silver__optimism_submission_hashes.yml
@@ -16,9 +16,6 @@ models:
       - name: L1_SUBMISSION_BLOCK_TIMESTAMP
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_LTZ
@@ -71,9 +68,6 @@ models:
       - name: _INSERTED_TIMESTAMP
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_LTZ


### PR DESCRIPTION
1. Removed recency tests on OP submission and state hash events, due to bedrock upgrades these events have been deprecated
2. [Optimism Bedrock - Notable Changes for Data Providers](https://docs.google.com/document/d/1P6V4gXVLhQXCmErIKRqtBtk3jDW8axGVscAGQ6YM8DM/edit#heading=h.wd2ymjqtf7vx)