### PR TITLE
AN-3306/swap-public-to-utils

### DIFF
--- a/models/aave/gold/aave__ez_borrows.sql
+++ b/models/aave/gold/aave__ez_borrows.sql
@@ -31,10 +31,10 @@ borrow AS (
             WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))
         END AS onBehalfOf,
         CASE
-            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN utils.udf_hex_to_int(
                 topics [3] :: STRING
             ) :: INTEGER
-            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN utils.udf_hex_to_int(
                 topics [3] :: STRING
             ) :: INTEGER
         END AS refferal,
@@ -42,26 +42,26 @@ borrow AS (
             WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40))
         END AS userAddress,
         CASE
-            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: INTEGER
-            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: INTEGER
         END AS borrow_quantity,
         CASE
-            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             ) :: INTEGER
-            WHEN topics [1] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [1] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: INTEGER
         END AS borrow_rate_mode,
         CASE
-            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xc6a898309e823ee50bac64e45ca8adba6690e99e7841c45d754e2a38e9019d9b' THEN utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             ) :: INTEGER
-            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x1e77446728e5558aa1b7e81e0cdab9cc1b075ba893b740600c76a315c2caa553' THEN utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             ) :: INTEGER
         END AS borrowrate,

--- a/models/aave/gold/aave__ez_deposits.sql
+++ b/models/aave/gold/aave__ez_deposits.sql
@@ -23,7 +23,7 @@ WITH deposits AS(
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS reserve_1,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS onBehalfOf,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) :: INTEGER AS refferal,
         CASE
@@ -31,10 +31,10 @@ WITH deposits AS(
             WHEN topics [0] :: STRING = '0xc12c57b1c73a2c3a2ea4613e9476abb3d8d146857aab7329e24243fb59710c82' THEN CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))
         END AS userAddress,
         CASE
-            WHEN topics [0] :: STRING = '0xde6857219544bb5b7746f48ed30be6386fefc61b2f864cacf559893bf50fd951' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xde6857219544bb5b7746f48ed30be6386fefc61b2f864cacf559893bf50fd951' THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: INTEGER
-            WHEN topics [0] :: STRING = '0xc12c57b1c73a2c3a2ea4613e9476abb3d8d146857aab7329e24243fb59710c82' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xc12c57b1c73a2c3a2ea4613e9476abb3d8d146857aab7329e24243fb59710c82' THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: INTEGER
         END AS deposit_quantity,

--- a/models/aave/gold/aave__ez_flashloans.sql
+++ b/models/aave/gold/aave__ez_flashloans.sql
@@ -30,13 +30,13 @@ WITH flashloan AS (
             WHEN topics [0] :: STRING = '0x631042c832b07452973831137f2d73e395028b44b250dedc5abb0ee766e168ac' THEN CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40))
             WHEN topics [0] :: STRING = '0x5b8f46461c1dd69fb968f1a003acee221ea3e19540e350233b612ddb43433b55' THEN CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))
         END AS asset_1,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS flashloan_quantity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS premium_quantity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER AS refferalCode,
         _log_id,

--- a/models/aave/gold/aave__ez_liquidations.sql
+++ b/models/aave/gold/aave__ez_liquidations.sql
@@ -24,17 +24,17 @@ WITH liquidation AS(
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS collateralAsset_1,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS debtAsset_1,
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS borrower_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS debt_to_cover_amount,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS liquidated_amount,
         CASE
             WHEN topics [0] :: STRING = '0xe413a321e8681d831f4dbccbca790d2952b56f977908e45be37335533e005286' THEN CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 25, 40))
             ELSE CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40))
         END AS liquidator_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS receiveAToken,
         _log_id,

--- a/models/aave/gold/aave__ez_repayments.sql
+++ b/models/aave/gold/aave__ez_repayments.sql
@@ -24,7 +24,7 @@ WITH repay AS(
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS reserve_1,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS borrower_address,
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS repayer,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS repayed_amount,
         _log_id,

--- a/models/aave/gold/aave__ez_votes.sql
+++ b/models/aave/gold/aave__ez_votes.sql
@@ -21,17 +21,17 @@ WITH base AS (
     block_timestamp,
     contract_address AS governance_contract,
     regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [0] :: STRING
     ) :: INTEGER AS proposal_id,
     CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS voter,
     CASE
-      WHEN PUBLIC.udf_hex_to_int(
+      WHEN utils.udf_hex_to_int(
         segmented_data [1] :: STRING
       ) :: INTEGER = 1 THEN TRUE
       ELSE FALSE
     END AS support,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) AS voting_power,
     tx_hash,

--- a/models/aave/gold/aave__ez_withdraws.sql
+++ b/models/aave/gold/aave__ez_withdraws.sql
@@ -26,7 +26,7 @@ WITH withdraw AS(
             WHEN topics [0] :: STRING = '0x3115d1449a7b732c986cba18244e897a450f61e1bb8d589cd2e69e6c8924f9f7' THEN CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40))
             ELSE origin_from_address
         END AS depositor,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS withdraw_amount,
         _inserted_timestamp,

--- a/models/aave/silver/silver__aave_liquidity_mining.sql
+++ b/models/aave/silver/silver__aave_liquidity_mining.sql
@@ -14,7 +14,7 @@ WITH aave_base AS (
         function_input AS token_address,
         _inserted_timestamp,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS emission_per_second
     FROM

--- a/models/aave/silver/silver__aave_market_stats.sql
+++ b/models/aave/silver/silver__aave_market_stats.sql
@@ -34,34 +34,34 @@ AND _inserted_timestamp >= (
 decoded AS (
     SELECT
         *,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: FLOAT AS availableLiquidity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: FLOAT AS totalStableDebt,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: FLOAT AS totalVariableDebt,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: FLOAT AS liquidityRate,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [4] :: STRING
         ) :: FLOAT AS variableBorrowRate,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [5] :: STRING
         ) :: FLOAT AS stableBorrowRate,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [6] :: STRING
         ) :: FLOAT AS averageStableBorrowRate,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [7] :: STRING
         ) :: FLOAT AS liquidityIndex,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [8] :: STRING
         ) :: FLOAT AS variableBorrowIndex,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [9] :: STRING
         ) :: FLOAT AS lastUpdateTimestamp
     FROM

--- a/models/aave/silver/silver__aave_oracle_prices.sql
+++ b/models/aave/silver/silver__aave_oracle_prices.sql
@@ -10,7 +10,7 @@ WITH oracle_reads AS (
   SELECT
     block_number,
     contract_address AS oracle_contract,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       read_output :: STRING
     ) AS value_ethereum,
     _inserted_timestamp,

--- a/models/beacon_chain/silver/silver__eth_staking_deposits.sql
+++ b/models/beacon_chain/silver/silver__eth_staking_deposits.sql
@@ -36,7 +36,7 @@ WITH deposit_evt AS (
         CONCAT('0x', SUBSTR(segmented_data [9] :: STRING, 25, 40)) AS withdrawal_address,
         CONCAT('0x', SUBSTR(segmented_data [11] :: STRING, 0, 16)) AS amount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(SUBSTR(amount, 15, 2) || SUBSTR(amount, 13, 2) || SUBSTR(amount, 11, 2) || SUBSTR(amount, 9, 2) || SUBSTR(amount, 7, 2) || SUBSTR(amount, 5, 2) || SUBSTR(amount, 3, 2))
+            utils.udf_hex_to_int(SUBSTR(amount, 15, 2) || SUBSTR(amount, 13, 2) || SUBSTR(amount, 11, 2) || SUBSTR(amount, 9, 2) || SUBSTR(amount, 7, 2) || SUBSTR(amount, 5, 2) || SUBSTR(amount, 3, 2))
         ) / pow(
             10,
             9
@@ -49,7 +49,7 @@ WITH deposit_evt AS (
         ) AS signature,
         CONCAT('0x', SUBSTR(segmented_data [17] :: STRING, 0, 16)) AS INDEX,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(SUBSTR(INDEX, 15, 2) || SUBSTR(INDEX, 13, 2) || SUBSTR(INDEX, 11, 2) || SUBSTR(INDEX, 9, 2) || SUBSTR(INDEX, 7, 2) || SUBSTR(INDEX, 5, 2) || SUBSTR(INDEX, 3, 2))
+            utils.udf_hex_to_int(SUBSTR(INDEX, 15, 2) || SUBSTR(INDEX, 13, 2) || SUBSTR(INDEX, 11, 2) || SUBSTR(INDEX, 9, 2) || SUBSTR(INDEX, 7, 2) || SUBSTR(INDEX, 5, 2) || SUBSTR(INDEX, 3, 2))
         ) AS deposit_index,
         _log_id,
         _inserted_timestamp

--- a/models/beacon_chain/silver/silver__eth_staking_withdrawals.sql
+++ b/models/beacon_chain/silver/silver__eth_staking_withdrawals.sql
@@ -12,7 +12,7 @@ WITH withdrawal_blocks AS (
         HASH AS block_hash,
         withdrawals AS withdrawals_data,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 VALUE :amount :: STRING
             )
         ) / pow(
@@ -22,12 +22,12 @@ WITH withdrawal_blocks AS (
         VALUE :address :: STRING AS withdrawal_address,
         withdrawals_root,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 VALUE :index :: STRING
             )
         ) AS withdrawal_index,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 VALUE :validatorIndex :: STRING
             )
         ) AS validator_index,

--- a/models/chainlink/silver/silver__chainlink_feeds.sql
+++ b/models/chainlink/silver/silver__chainlink_feeds.sql
@@ -9,7 +9,7 @@ WITH base AS (
         contract_address,
         block_number,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 read_output :: STRING
             )
         ) AS read_result,

--- a/models/compound/gold/compound__ez_borrows.sql
+++ b/models/compound/gold/compound__ez_borrows.sql
@@ -36,13 +36,13 @@ comp_borrows AS (
     event_index,
     regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS borrower,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [1] :: STRING
     ) :: INTEGER AS loan_amount_raw,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) :: INTEGER AS accountBorrows,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [3] :: STRING
     ) :: INTEGER AS totalBorrows,
     contract_address AS ctoken,

--- a/models/compound/gold/compound__ez_deposits.sql
+++ b/models/compound/gold/compound__ez_deposits.sql
@@ -35,10 +35,10 @@ comp_deposits AS (
     block_timestamp,
     contract_address AS ctoken,
     regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) :: INTEGER AS mintTokens_raw,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [1] :: STRING
     ) :: INTEGER AS mintAmount_raw,
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS supplier,

--- a/models/compound/gold/compound__ez_liquidations.sql
+++ b/models/compound/gold/compound__ez_liquidations.sql
@@ -38,10 +38,10 @@ comp_liquidations AS (
     CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS borrower,
     contract_address AS ctoken,
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS liquidator,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [4] :: STRING
     ) :: INTEGER AS seizeTokens_raw,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) :: INTEGER AS repayAmount_raw,
     CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS cTokenCollateral,

--- a/models/compound/gold/compound__ez_redemptions.sql
+++ b/models/compound/gold/compound__ez_redemptions.sql
@@ -35,10 +35,10 @@ comp_redemptions AS (
         block_timestamp,
         contract_address AS ctoken,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS received_amount_raw,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER AS redeemed_ctoken_raw,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS redeemer,

--- a/models/compound/gold/compound__ez_repayments.sql
+++ b/models/compound/gold/compound__ez_repayments.sql
@@ -37,7 +37,7 @@ comp_repayments AS (
     CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS borrower,
     contract_address AS ctoken,
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS payer,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) :: INTEGER AS repayed_amount_raw,
     tx_hash,

--- a/models/compound/silver/silver__comp_market_stats.sql
+++ b/models/compound/silver/silver__comp_market_stats.sql
@@ -80,7 +80,7 @@ total_supply AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS total_supply
     FROM
@@ -92,7 +92,7 @@ borrow_rate_per_block AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS borrow_rate_per_block
     FROM
@@ -104,7 +104,7 @@ exchange_rate_stored AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS exchange_rate_stored
     FROM
@@ -116,7 +116,7 @@ supply_rate_per_block AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS supply_rate_per_block
     FROM
@@ -128,7 +128,7 @@ total_borrows AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS total_borrows
     FROM
@@ -140,7 +140,7 @@ total_reserves AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS total_reserves
     FROM
@@ -152,7 +152,7 @@ comp_supply_speeds AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS comp_supply_speeds
     FROM
@@ -164,7 +164,7 @@ comp_borrow_speeds AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS comp_borrow_speeds
     FROM
@@ -176,7 +176,7 @@ comp_speeds AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS comp_speeds
     FROM

--- a/models/silver/balances/silver__eth_balances.sql
+++ b/models/silver/balances/silver__eth_balances.sql
@@ -13,7 +13,7 @@ SELECT
     block_timestamp,
     address,
     TRY_TO_NUMBER(
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :result :: STRING
         )
     ) AS balance,

--- a/models/silver/balances/silver__token_balances.sql
+++ b/models/silver/balances/silver__token_balances.sql
@@ -14,7 +14,7 @@ SELECT
     address,
     contract_address,
     TRY_TO_NUMBER(
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :result :: STRING
         )
     ) AS balance,

--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -8,39 +8,39 @@
 
 SELECT
     block_number,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :baseFeePerGas :: STRING
     ) :: INT AS base_fee_per_gas,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :difficulty :: STRING
     ) :: INT AS difficulty,
     DATA :result :extraData :: STRING AS extra_data,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :gasLimit :: STRING
     ) :: INT AS gas_limit,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :gasUsed :: STRING
     ) :: INT AS gas_used,
     DATA :result :hash :: STRING AS HASH,
     DATA :result :logsBloom :: STRING AS logs_bloom,
     DATA :result :miner :: STRING AS miner,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :nonce :: STRING
     ) :: INT AS nonce,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :number :: STRING
     ) :: INT AS NUMBER,
     DATA :result :parentHash :: STRING AS parent_hash,
     DATA :result :receiptsRoot :: STRING AS receipts_root,
     DATA :result :sha3Uncles :: STRING AS sha3_uncles,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :size :: STRING
     ) :: INT AS SIZE,
     DATA :result :stateRoot :: STRING AS state_root,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :timestamp :: STRING
     ) :: TIMESTAMP AS block_timestamp,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         DATA :result :totalDifficulty :: STRING
     ) :: INT AS total_difficulty,
     ARRAY_SIZE(

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -42,7 +42,7 @@ flat_logs AS (
         VALUE :address :: STRING AS contract_address,
         VALUE :blockHash :: STRING AS block_hash,
         VALUE :data :: STRING AS DATA,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             VALUE :logIndex :: STRING
         ) :: INT AS event_index,
         VALUE :removed :: BOOLEAN AS event_removed,

--- a/models/silver/core/silver__receipts.sql
+++ b/models/silver/core/silver__receipts.sql
@@ -41,25 +41,25 @@ FINAL AS (
     SELECT
         block_number,
         DATA :blockHash :: STRING AS block_hash,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :blockNumber :: STRING
         ) :: INT AS blockNumber,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :cumulativeGasUsed :: STRING
         ) :: INT AS cumulative_gas_used,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :effectiveGasPrice :: STRING
         ) :: INT / pow(
             10,
             9
         ) AS effective_gas_price,
         DATA :from :: STRING AS from_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :gasUsed :: STRING
         ) :: INT AS gas_used,
         DATA :logs AS logs,
         DATA :logsBloom :: STRING AS logs_bloom,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :status :: STRING
         ) :: INT AS status,
         CASE
@@ -76,10 +76,10 @@ FINAL AS (
             ELSE to_address1
         END AS to_address,
         DATA :transactionHash :: STRING AS tx_hash,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :transactionIndex :: STRING
         ) :: INT AS POSITION,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :type :: STRING
         ) :: INT AS TYPE,
         _inserted_timestamp

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -83,10 +83,10 @@ base_table AS (
 flattened_traces AS (
     SELECT
         DATA :from :: STRING AS from_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :gas :: STRING
         ) AS gas,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :gasUsed :: STRING
         ) AS gas_used,
         DATA :input :: STRING AS input,
@@ -95,7 +95,7 @@ flattened_traces AS (
         DATA :to :: STRING AS to_address,
         DATA :type :: STRING AS TYPE,
         CASE
-            WHEN DATA :type :: STRING = 'CALL' THEN PUBLIC.udf_hex_to_int(
+            WHEN DATA :type :: STRING = 'CALL' THEN utils.udf_hex_to_int(
                 DATA :value :: STRING
             ) / pow(
                 10,

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -36,17 +36,17 @@ base_tx AS (
     SELECT
         A.block_number AS block_number,
         A.data :blockHash :: STRING AS block_hash,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :blockNumber :: STRING
         ) :: INT AS blockNumber,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :chainId :: STRING
         ) :: INT AS chain_id,
         A.data :from :: STRING AS from_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :gas :: STRING
         ) :: INT AS gas,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :gasPrice :: STRING
         ) :: INT / pow(
             10,
@@ -59,19 +59,19 @@ base_tx AS (
             1,
             10
         ) AS origin_function_signature,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :maxFeePerGas :: STRING
         ) :: INT / pow(
             10,
             9
         ) AS max_fee_per_gas,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :maxPriorityFeePerGas :: STRING
         ) :: INT / pow(
             10,
             9
         ) AS max_priority_fee_per_gas,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :nonce :: STRING
         ) :: INT AS nonce,
         A.data :r :: STRING AS r,
@@ -81,12 +81,12 @@ base_tx AS (
             WHEN to_address1 = '' THEN NULL
             ELSE to_address1
         END AS to_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :transactionIndex :: STRING
         ) :: INT AS POSITION,
         A.data :type :: STRING AS TYPE,
         A.data :v :: STRING AS v,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             A.data :value :: STRING
         ) / pow(
             10,

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -145,7 +145,7 @@ SELECT
     MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_name,
     MIN(CASE 
             WHEN read_result::STRING = '0x' THEN NULL
-            ELSE ethereum.public.udf_hex_to_int(LEFT(read_result::STRING,66))
+            ELSE utils.udf_hex_to_int(LEFT(read_result::STRING,66))
         END)::INTEGER  AS pool_decimals,
     MAX(_inserted_timestamp) AS _inserted_timestamp
 FROM pool_details

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -28,7 +28,7 @@ swaps_base AS (
         (
             CASE
                 WHEN segmented_data [0] = '0x' THEN NULL
-                ELSE ethereum.public.udf_hex_to_int(
+                ELSE utils.udf_hex_to_int(
                     segmented_data [0] :: STRING
                 )
             END
@@ -36,7 +36,7 @@ swaps_base AS (
         (
             CASE
                 WHEN segmented_data [1] = '0x' THEN NULL
-                ELSE ethereum.public.udf_hex_to_int(
+                ELSE utils.udf_hex_to_int(
                     segmented_data [1] :: STRING
                 )
             END

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -293,7 +293,7 @@ SELECT
         TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
     MIN(CASE 
             WHEN p.read_result::STRING = '0x' THEN NULL
-            ELSE ethereum.public.udf_hex_to_int(LEFT(p.read_result::STRING,66))
+            ELSE utils.udf_hex_to_int(LEFT(p.read_result::STRING,66))
         END)::INTEGER  AS pool_decimals,
     CONCAT(
         t.contract_address,

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -55,16 +55,16 @@ curve_base AS (
         pool_name,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS sold_id,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS tokens_sold,
-        TRY_CAST(PUBLIC.udf_hex_to_int(
+        TRY_CAST(utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) AS INTEGER) AS bought_id,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS tokens_bought,
         _log_id,
@@ -109,7 +109,7 @@ token_transfers AS (
         tx_hash,
         contract_address AS token_address,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 DATA :: STRING
             )
         ) AS amount,

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -41,12 +41,12 @@ sell_base_token AS (
         regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS seller_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS payBase,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS receiveQuote,
@@ -94,12 +94,12 @@ buy_base_token AS (
         regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS buyer_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS receiveBase,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS payQuote,

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -52,12 +52,12 @@ swaps_base AS (
             )
         ) AS toToken,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS fromAmount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS toAmount,

--- a/models/silver/dex/frax/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/frax/silver_dex__fraxswap_pools.sql
@@ -15,7 +15,7 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INT AS pool_id,
         _log_id,

--- a/models/silver/dex/frax/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/frax/silver_dex__fraxswap_swaps.sql
@@ -27,22 +27,22 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS amount1Out,

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -47,12 +47,12 @@ router_swaps_base AS (
             )
         ) AS tokenOut,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [5] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [6] :: STRING
             )
         ) AS amountOut,
@@ -111,12 +111,12 @@ swaps_base AS (
             )
         ) AS tokenOut,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [5] :: STRING
             )
         ) AS amountOut,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -16,12 +16,12 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS ampBps,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         ) AS totalPool,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -27,27 +27,27 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS amount1Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS feeInPrecision,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -16,17 +16,17 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS ampBps,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         ) AS feeUnits,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             )
         ) AS totalPool,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -27,27 +27,27 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS amount1Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS feeInPrecision,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -14,9 +14,9 @@ WITH pool_creation AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(topics [3] :: STRING)) AS swapFeeUnits,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(topics [3] :: STRING)) AS swapFeeUnits,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             )
         ) AS tickDistance,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -27,29 +27,29 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS reipient_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [0] :: STRING
             )
         ) AS deltaQty0,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [1] :: STRING
             )
         ) AS deltaQty1,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS sqrtP,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS liquidity,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [4] :: STRING
             )

--- a/models/silver/dex/maverick/silver_dex__maverick_pools.sql
+++ b/models/silver/dex/maverick/silver_dex__maverick_pools.sql
@@ -14,28 +14,28 @@ WITH pools AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS fee,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         ) AS tickSpacing,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 segmented_data [3] :: STRING
             )
         ) AS activeTick,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [4] :: STRING
             )
         ) AS lookback,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [5] :: STRING
             )
         ) AS protocolFeeRatio,

--- a/models/silver/dex/maverick/silver_dex__maverick_swaps.sql
+++ b/models/silver/dex/maverick/silver_dex__maverick_swaps.sql
@@ -42,7 +42,7 @@ swaps_base AS (
         ) AS recipient_address,
         CASE
             WHEN TRY_TO_NUMBER(
-                ethereum.public.udf_hex_to_int(
+                utils.udf_hex_to_int(
                     l_segmented_data [2] :: STRING
                 )
             ) = 0 THEN FALSE
@@ -50,24 +50,24 @@ swaps_base AS (
         END AS tokenAin,
         CASE
             WHEN TRY_TO_NUMBER(
-                ethereum.public.udf_hex_to_int(
+                utils.udf_hex_to_int(
                     l_segmented_data [3] :: STRING
                 )
             ) = 0 THEN FALSE
             ELSE TRUE
         END AS exactOutput,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [5] :: STRING
             )
         ) AS amountOut,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [6] :: STRING
             )

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_pools.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_pools.sql
@@ -15,7 +15,7 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INT AS pool_id,
         _log_id,

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_swaps.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_swaps.sql
@@ -25,22 +25,22 @@ swaps_base AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: INTEGER
         ) AS amount0In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: INTEGER
         ) AS amount1In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             ) :: INTEGER
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             ) :: INTEGER
         ) AS amount1Out,

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_swaps.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_swaps.sql
@@ -27,22 +27,22 @@ swaps_base AS (
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
-            ) :: INTEGER
+            )
         ) AS amount0In,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
-            ) :: INTEGER
+            )
         ) AS amount1In,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
-            ) :: INTEGER
+            )
         ) AS amount0Out,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
-            ) :: INTEGER
+            )
         ) AS amount1Out,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v2_mm_swaps.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v2_mm_swaps.sql
@@ -19,7 +19,7 @@ WITH swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS user_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS mm_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS nonce,
@@ -35,12 +35,12 @@ WITH swaps_base AS (
             ELSE quoteToken1
         END AS quoteToken,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS baseTokenAmount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [5] :: STRING
             )
         ) AS quoteTokenAmount,

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v3_pools.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v3_pools.sql
@@ -14,13 +14,13 @@ WITH created_pools AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 topics [3] :: STRING
             )
         ) AS fee,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 segmented_data [0] :: STRING
             )

--- a/models/silver/dex/pancake/silver_dex__pancakeswap_v3_swaps.sql
+++ b/models/silver/dex/pancake/silver_dex__pancakeswap_v3_swaps.sql
@@ -29,41 +29,41 @@ base_swaps AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS recipient_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS sqrtPriceX96,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS liquidity,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [4] :: STRING
             )
         ) AS tick,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [5] :: STRING
             )
         ) AS protocolFeesToken0,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [6] :: STRING
             )

--- a/models/silver/dex/shibaswap/silver_dex__shibaswap_pools.sql
+++ b/models/silver/dex/shibaswap/silver_dex__shibaswap_pools.sql
@@ -15,7 +15,7 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INT AS pool_id,
         _log_id,

--- a/models/silver/dex/shibaswap/silver_dex__shibaswap_swaps.sql
+++ b/models/silver/dex/shibaswap/silver_dex__shibaswap_swaps.sql
@@ -25,22 +25,22 @@ swaps_base AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             )
         ) AS amount1Out,

--- a/models/silver/dex/synthetix/silver_dex__synthetix_swaps.sql
+++ b/models/silver/dex/synthetix/silver_dex__synthetix_swaps.sql
@@ -18,10 +18,10 @@ WITH swaps_base AS (
         'SynthExchange' AS event_name,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS amount_in_unadj,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS amount_out_unadj,
         REGEXP_REPLACE(HEX_DECODE_STRING(

--- a/models/silver/dex/uni_sushi_v2/silver_dex__pools.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__pools.sql
@@ -50,12 +50,12 @@ uniswap_v3_pools AS (
         tx_hash,
         contract_address AS factory_address,
         'PoolCreated' AS event_name,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) :: INTEGER AS fee,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTRING(segmented_data [1] :: STRING, 25, 40)) AS pool_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS tickSpacing,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,

--- a/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_daily_metrics.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_daily_metrics.sql
@@ -69,7 +69,7 @@ balance_of_slp_staked AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS balance_of_slp_staked
     FROM
@@ -81,7 +81,7 @@ total_supply_of_SLP AS (
     SELECT
         block_number,
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS total_supply_of_SLP
     FROM

--- a/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_daily_metrics.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_daily_metrics.sql
@@ -69,7 +69,7 @@ balance_of_slp_staked AS (
     SELECT
         block_number,
         contract_address,
-        utils.udf_hex_to_int(
+        PUBLIC.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS balance_of_slp_staked
     FROM
@@ -81,7 +81,7 @@ total_supply_of_SLP AS (
     SELECT
         block_number,
         contract_address,
-        utils.udf_hex_to_int(
+        PUBLIC.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS total_supply_of_SLP
     FROM

--- a/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_weekly_metrics.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_weekly_metrics.sql
@@ -37,16 +37,16 @@ v1_allocpoint_per_pool AS (
       ELSE contract_address
     END AS pool_address,
     CASE
-      WHEN function_signature = '0x1526fe27' THEN PUBLIC.udf_hex_to_int(
+      WHEN function_signature = '0x1526fe27' THEN utils.udf_hex_to_int(
         segmented_data [1] :: STRING
       )
-      ELSE PUBLIC.udf_hex_to_int(
+      ELSE utils.udf_hex_to_int(
         segmented_data [0] :: STRING
       )
     END AS allocation_points,
     A.block_number,
     function_signature,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     CASE
@@ -74,7 +74,7 @@ v2_poolid_per_pool AS (
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
     A.block_number,
     function_signature,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     function_input,
@@ -95,7 +95,7 @@ v2_allocpoint_per_poolid AS (
   SELECT
     A.contract_address,
     A.block_number,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     function_input,
@@ -103,7 +103,7 @@ v2_allocpoint_per_poolid AS (
     'poolInfo' AS function_name,
     function_signature,
     A._inserted_timestamp,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) AS allocation_points
   FROM

--- a/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_weekly_metrics.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__v2_pool_weekly_metrics.sql
@@ -37,16 +37,16 @@ v1_allocpoint_per_pool AS (
       ELSE contract_address
     END AS pool_address,
     CASE
-      WHEN function_signature = '0x1526fe27' THEN utils.udf_hex_to_int(
+      WHEN function_signature = '0x1526fe27' THEN PUBLIC.udf_hex_to_int(
         segmented_data [1] :: STRING
       )
-      ELSE utils.udf_hex_to_int(
+      ELSE PUBLIC.udf_hex_to_int(
         segmented_data [0] :: STRING
       )
     END AS allocation_points,
     A.block_number,
     function_signature,
-    utils.udf_hex_to_int(
+    PUBLIC.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     CASE
@@ -74,7 +74,7 @@ v2_poolid_per_pool AS (
     CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
     A.block_number,
     function_signature,
-    utils.udf_hex_to_int(
+    PUBLIC.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     function_input,
@@ -95,7 +95,7 @@ v2_allocpoint_per_poolid AS (
   SELECT
     A.contract_address,
     A.block_number,
-    utils.udf_hex_to_int(
+    PUBLIC.udf_hex_to_int(
       A.function_input :: STRING
     ) AS pid,
     function_input,
@@ -103,7 +103,7 @@ v2_allocpoint_per_poolid AS (
     'poolInfo' AS function_name,
     function_signature,
     A._inserted_timestamp,
-    utils.udf_hex_to_int(
+    PUBLIC.udf_hex_to_int(
       segmented_data [2] :: STRING
     ) AS allocation_points
   FROM

--- a/models/silver/dex/uni_sushi_v2/silver_dex__v2_swaps.sql
+++ b/models/silver/dex/uni_sushi_v2/silver_dex__v2_swaps.sql
@@ -34,16 +34,16 @@ swap_events AS (
         'Swap' AS event_name,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(segmented_data [0] :: STRING)
+            utils.udf_hex_to_int(segmented_data [0] :: STRING)
         ) AS amount0In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(segmented_data [1] :: STRING)
+            utils.udf_hex_to_int(segmented_data [1] :: STRING)
         ) AS amount1In,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(segmented_data [2] :: STRING)
+            utils.udf_hex_to_int(segmented_data [2] :: STRING)
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(segmented_data [3] :: STRING)
+            utils.udf_hex_to_int(segmented_data [3] :: STRING)
         ) AS amount1Out,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,

--- a/models/silver/maker/base/cat/silver_maker__cat_bite.sql
+++ b/models/silver/maker/base/cat/silver_maker__cat_bite.sql
@@ -49,20 +49,20 @@ FINAL AS (
         origin_to_address,
         TRY_HEX_DECODE_STRING(REPLACE(topics [1] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS urn_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS ink,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) AS art,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) / pow(
             10,
             45
         ) AS tab,
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS flip,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [4] :: STRING
         ) AS id,
         _inserted_timestamp,

--- a/models/silver/maker/base/cdp/silver_maker__cdp_flux.sql
+++ b/models/silver/maker/base/cdp/silver_maker__cdp_flux.sql
@@ -48,11 +48,11 @@ FINAL AS (
         origin_from_address,
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [2] :: STRING
         ) :: INTEGER AS cdp,
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS dst,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [4] :: STRING
         ) / pow(

--- a/models/silver/maker/base/cdp/silver_maker__cdp_frob.sql
+++ b/models/silver/maker/base/cdp/silver_maker__cdp_frob.sql
@@ -48,17 +48,17 @@ FINAL AS (
         origin_from_address,
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [2] :: STRING
         ) :: INTEGER AS cdp,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [3] :: STRING
         ) / pow(
             10,
             18
         ) AS dink,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [4] :: STRING
         ) / pow(

--- a/models/silver/maker/base/cdp/silver_maker__cdp_move.sql
+++ b/models/silver/maker/base/cdp/silver_maker__cdp_move.sql
@@ -48,11 +48,11 @@ FINAL AS (
         origin_from_address,
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [2] :: STRING
         ) :: INTEGER AS cdp,
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS dst,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [4] :: STRING
         ) / pow(

--- a/models/silver/maker/base/cdp/silver_maker__cdp_newcdp.sql
+++ b/models/silver/maker/base/cdp/silver_maker__cdp_newcdp.sql
@@ -49,7 +49,7 @@ FINAL AS (
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS own,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) :: INTEGER AS cdp,
         _inserted_timestamp,

--- a/models/silver/maker/base/dai_join/silver_maker__dai_join_exit.sql
+++ b/models/silver/maker/base/dai_join/silver_maker__dai_join_exit.sql
@@ -50,7 +50,7 @@ FINAL AS (
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr1,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS usr2,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) :: INTEGER / pow(
             10,

--- a/models/silver/maker/base/dai_join/silver_maker__dai_join_join.sql
+++ b/models/silver/maker/base/dai_join/silver_maker__dai_join_join.sql
@@ -49,7 +49,7 @@ FINAL AS (
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS usr1,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS usr2,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) :: INTEGER / pow(
             10,

--- a/models/silver/maker/base/dog/silver_maker__dog_bark.sql
+++ b/models/silver/maker/base/dog/silver_maker__dog_bark.sql
@@ -49,16 +49,16 @@ FINAL AS (
         origin_to_address,
         TRY_HEX_DECODE_STRING(REPLACE(topics [1] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS urn_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) AS id,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS ink,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) AS art,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/dss_flash/silver_maker__dss_flashloan.sql
+++ b/models/silver/maker/base/dss_flash/silver_maker__dss_flashloan.sql
@@ -52,13 +52,13 @@ FINAL AS (
         origin_to_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS receiver,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS token,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER / pow(
             10,
             18
         ) AS amount,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER / pow(
             10,

--- a/models/silver/maker/base/mcd_pot/silver_maker__pot_exit.sql
+++ b/models/silver/maker/base/mcd_pot/silver_maker__pot_exit.sql
@@ -47,7 +47,7 @@ FINAL AS (
         block_timestamp,
         origin_from_address,
         origin_to_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/mcd_pot/silver_maker__pot_join.sql
+++ b/models/silver/maker/base/mcd_pot/silver_maker__pot_join.sql
@@ -47,7 +47,7 @@ FINAL AS (
         block_timestamp,
         origin_from_address,
         origin_to_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/vat/silver_maker__vat_file.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_file.sql
@@ -51,7 +51,7 @@ FINAL AS (
         _log_id,
         TRY_HEX_DECODE_STRING(REPLACE(topics [1] :: STRING, '0x', '')) AS ilk_l,
         TRY_HEX_DECODE_STRING(REPLACE(topics [2] :: STRING, '0x', '')) AS what,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) AS DATA,
         contract_address

--- a/models/silver/maker/base/vat/silver_maker__vat_flux.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_flux.sql
@@ -52,7 +52,7 @@ FINAL AS (
         TRY_HEX_DECODE_STRING(REPLACE(segmented_data [2] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS receiver,
         CONCAT('0x', SUBSTR(segmented_data [4] :: STRING, 25, 40)) AS sender,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [5] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/vat/silver_maker__vat_fold.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_fold.sql
@@ -51,7 +51,7 @@ FINAL AS (
         _log_id,
         TRY_HEX_DECODE_STRING(REPLACE(topics [1] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS u,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/vat/silver_maker__vat_fork.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_fork.sql
@@ -52,14 +52,14 @@ FINAL AS (
         TRY_HEX_DECODE_STRING(REPLACE(segmented_data [2] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS src,
         CONCAT('0x', SUBSTR(segmented_data [4] :: STRING, 25, 40)) AS dst,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [5] :: STRING
         ) / pow(
             10,
             18
         ) AS dink,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [6] :: STRING
         ) / pow(

--- a/models/silver/maker/base/vat/silver_maker__vat_frob.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_frob.sql
@@ -57,14 +57,14 @@ FINAL AS (
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS u_address,
         CONCAT('0x', SUBSTR(segmented_data [4] :: STRING, 25, 40)) AS v_address,
         CONCAT('0x', SUBSTR(segmented_data [5] :: STRING, 25, 40)) AS w_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [6] :: STRING
         ) / pow(
             10,
             18
         ) AS dink,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [7] :: STRING
         ) / pow(

--- a/models/silver/maker/base/vat/silver_maker__vat_move.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_move.sql
@@ -49,7 +49,7 @@ FINAL AS (
         _log_id,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS src_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS dst_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [3] :: STRING
         ) / pow(

--- a/models/silver/maker/base/vat/silver_maker__vat_slip.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_slip.sql
@@ -51,7 +51,7 @@ FINAL AS (
         _log_id,
         TRY_HEX_DECODE_STRING(REPLACE(segmented_data [2] :: STRING, '0x', '')) AS ilk_l,
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS usr,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [4] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/base/vat/silver_maker__vat_suck.sql
+++ b/models/silver/maker/base/vat/silver_maker__vat_suck.sql
@@ -49,7 +49,7 @@ FINAL AS (
         _log_id,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS u_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS v_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) / pow(
             10,

--- a/models/silver/maker/ez_models/silver_maker__delegations.sql
+++ b/models/silver/maker/ez_models/silver_maker__delegations.sql
@@ -41,7 +41,7 @@ delegate_actions AS (
             WHEN topics [0] :: STRING = '0xce6c5af8fd109993cb40da4d5dc9e4dd8e61bc2e48f1e3901472141e4f56f293' THEN 'undelegate'
         END AS tx_event,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS delegate,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :: STRING
         ) :: INT AS amount_delegated_unadjusted,
         amount_delegated_unadjusted / pow(

--- a/models/silver/maker/ez_models/silver_maker__governance_votes.sql
+++ b/models/silver/maker/ez_models/silver_maker__governance_votes.sql
@@ -12,10 +12,10 @@ SELECT
     event_index,
     CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS voter,
     contract_address AS polling_contract,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         topics [3] :: STRING
     ) :: INT AS vote_option,
-    PUBLIC.udf_hex_to_int(
+    utils.udf_hex_to_int(
         topics [2] :: STRING
     ) :: INT AS proposal_id,
     _inserted_timestamp,

--- a/models/silver/maker/ez_models/silver_maker__urns.sql
+++ b/models/silver/maker/ez_models/silver_maker__urns.sql
@@ -132,7 +132,7 @@ SELECT
     block_number,
     function_sig,
     function_input,
-    PUBLIC.udf_hex_to_int(function_input) AS vault_no,
+    utils.udf_hex_to_int(function_input) AS vault_no,
     CONCAT('0x', SUBSTR(read_result :: STRING, 27, 40)) AS urn_address
 FROM
     FINAL

--- a/models/silver/maker/ez_models/silver_maker__vault_creation.sql
+++ b/models/silver/maker/ez_models/silver_maker__vault_creation.sql
@@ -52,7 +52,7 @@ newcdps AS (
         _inserted_timestamp,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS user_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS owner_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [3] :: STRING
         ) AS vault_no,
         origin_to_address AS vault

--- a/models/silver/optimism/silver__optimism_state_hashes.sql
+++ b/models/silver/optimism/silver__optimism_state_hashes.sql
@@ -10,17 +10,17 @@ WITH base AS (
     SELECT
         *,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [1] :: STRING
         ) :: INTEGER AS batch_index,
         CONCAT(
             '0x',
             segmented_data [0] :: STRING
         ) AS batchRoot,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS batchSize,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER AS prevTotalElements,
         segmented_data [3] :: STRING AS extraData

--- a/models/silver/optimism/silver__optimism_submission_hashes.sql
+++ b/models/silver/optimism/silver__optimism_submission_hashes.sql
@@ -10,17 +10,17 @@ WITH base AS (
     SELECT
         *,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [1] :: STRING
         ) :: INTEGER AS batch_index,
         CONCAT(
             '0x',
             segmented_data [0] :: STRING
         ) AS batchRoot,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS batchSize,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER AS prevTotalElements,
         segmented_data [3] :: STRING AS extraData

--- a/models/silver/silver__token_meta_reads.sql
+++ b/models/silver/silver__token_meta_reads.sql
@@ -109,7 +109,7 @@ token_names AS (
         function_signature,
         read_output,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [1] :: STRING
         ) AS sub_len,
         TRY_HEX_DECODE_STRING(
@@ -142,7 +142,7 @@ token_symbols AS (
         function_signature,
         read_output,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [1] :: STRING
         ) AS sub_len,
         TRY_HEX_DECODE_STRING(

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -18,7 +18,7 @@ WITH logs AS (
         contract_address :: STRING AS contract_address,
         CONCAT('0x', SUBSTR(topics [1], 27, 40)) :: STRING AS from_address,
         CONCAT('0x', SUBSTR(topics [2], 27, 40)) :: STRING AS to_address,
-        PUBLIC.udf_hex_to_int(SUBSTR(DATA, 3, 64)) :: FLOAT AS raw_amount,
+        utils.udf_hex_to_int(SUBSTR(DATA, 3, 64)) :: FLOAT AS raw_amount,
         event_index :: FLOAT AS event_index,
         TO_TIMESTAMP_NTZ(_inserted_timestamp) AS _inserted_timestamp
     FROM

--- a/models/uniswapv3/silver/silver__univ3_lp_actions.sql
+++ b/models/uniswapv3/silver/silver__univ3_lp_actions.sql
@@ -63,40 +63,40 @@ lp_amounts AS (
         END AS action,
         contract_address AS pool_address,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS vault_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [2] :: STRING
         ) :: FLOAT AS tick_lower,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
                 's2c', 
                 topics [3] :: STRING
             ) :: FLOAT AS tick_upper,
         CASE
-            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [2] :: STRING
             )
-            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [1] :: STRING
             )
         END AS amount0,
         CASE
-            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [3] :: STRING
             )
-            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [2] :: STRING
             )
         END AS amount1,
         CASE
-            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [0] :: STRING
             )
-            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN PUBLIC.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN utils.udf_hex_to_int(
                 's2c',
                 segmented_data [1] :: STRING
             )
@@ -128,7 +128,7 @@ lp_amounts AS (
 nf_info AS (
     SELECT
         tx_hash,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             topics [1] :: STRING
         ) :: INTEGER AS nf_token_id,
         contract_address AS nf_position_manager_address,
@@ -136,13 +136,13 @@ nf_info AS (
             WHEN topics [0] :: STRING = '0x3067048beee31b25b2f1681f88dac838c8bba36af25bfb2b7cf7473a5847e35f' THEN 'INCREASE_LIQUIDITY'
             ELSE 'DECREASE_LIQUIDITY'
         END AS action,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS liquidity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) AS amount0,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) AS amount1,
         ROW_NUMBER() over(

--- a/models/uniswapv3/silver/silver__univ3_pool_stats.sql
+++ b/models/uniswapv3/silver/silver__univ3_pool_stats.sql
@@ -56,10 +56,10 @@ protocol_fees_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [0] :: STRING
         ) :: FLOAT AS token0_protocol_fees,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [1] :: STRING
         ) :: FLOAT AS token1_protocol_fees
     FROM
@@ -71,7 +71,7 @@ liquidity_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [0] :: STRING
         ) :: FLOAT AS liquidity
     FROM
@@ -83,7 +83,7 @@ feeGrowthGlobal1X128_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [0] :: STRING
         ) :: FLOAT AS feeGrowthGlobal1X128
     FROM
@@ -95,7 +95,7 @@ feeGrowthGlobal0X128_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [0] :: STRING
         ) :: FLOAT AS feeGrowthGlobal0X128
     FROM
@@ -107,26 +107,26 @@ slot0_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [0] :: STRING
         ) :: FLOAT AS sqrtPriceX96,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_output [1] :: STRING
         ) :: FLOAT AS tick,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [2] :: STRING
         ) :: FLOAT AS observationIndex,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [3] :: STRING
         ) :: FLOAT AS observationCardinality,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [4] :: STRING
         ) :: FLOAT AS observationCardinalityNext,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [5] :: STRING
         ) :: FLOAT AS feeProtocol,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [6] :: STRING
         ) :: FLOAT AS unlocked
     FROM

--- a/models/uniswapv3/silver/silver__univ3_pools.sql
+++ b/models/uniswapv3/silver/silver__univ3_pools.sql
@@ -13,11 +13,11 @@ WITH created_pools AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         LOWER(CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40))) AS token0_address,
         LOWER(CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))) AS token1_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [3] :: STRING
         ) :: INTEGER AS fee,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [0] :: STRING
         ) :: INTEGER AS tick_spacing,
@@ -44,8 +44,8 @@ initial_info AS (
     SELECT
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [0] :: STRING)) :: FLOAT AS init_sqrtPriceX96,
-        PUBLIC.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [1] :: STRING)) :: FLOAT AS init_tick,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [0] :: STRING)) :: FLOAT AS init_sqrtPriceX96,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [1] :: STRING)) :: FLOAT AS init_tick,
         pow(
             1.0001,
             init_tick

--- a/models/uniswapv3/silver/silver__univ3_position_collected_fees.sql
+++ b/models/uniswapv3/silver/silver__univ3_position_collected_fees.sql
@@ -36,19 +36,19 @@ collected_base AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS vault_address,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS owner,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [2] :: STRING
         ) AS tick_lower,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [3] :: STRING
         ) AS tick_upper,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [1] :: STRING
         ) AS amount0,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [2] :: STRING
         ) AS amount1
@@ -61,17 +61,17 @@ nf_token_id_base AS (
     SELECT
         tx_hash,
         contract_address AS nf_position_manager_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [1] :: STRING
         ) AS nf_token_id,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 27, 40)) AS liquidity_provider,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [1] :: STRING
         ) AS amount0,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [2] :: STRING
         ) AS amount1,

--- a/models/uniswapv3/silver/silver__univ3_positions.sql
+++ b/models/uniswapv3/silver/silver__univ3_positions.sql
@@ -41,38 +41,38 @@ position_reads_base AS (
     SELECT
         contract_address,
         block_number,
-        PUBLIC.udf_hex_to_int(CONCAT('0x', function_input :: STRING)) :: STRING AS nf_token_id,
+        utils.udf_hex_to_int(CONCAT('0x', function_input :: STRING)) :: STRING AS nf_token_id,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_data,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: FLOAT AS nonce,
         CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 27, 40)) AS OPERATOR,
         CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 27, 40)) AS token1,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [4] :: STRING
         ) :: FLOAT AS fee,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [5] :: STRING
         ) :: FLOAT AS tickLower,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [6] :: STRING
         ) :: FLOAT AS tickUpper,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [7] :: STRING
         ) :: FLOAT AS liquidity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [8] :: STRING
         ) :: FLOAT AS feeGrowthInside0LastX128,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [9] :: STRING
         ) :: FLOAT AS feeGrowthInside1LastX128,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [10] :: STRING
         ) :: FLOAT AS tokensOwed0,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [11] :: STRING
         ) :: FLOAT AS tokensOwed1
     FROM

--- a/models/uniswapv3/silver/silver__univ3_swaps.sql
+++ b/models/uniswapv3/silver/silver__univ3_swaps.sql
@@ -11,23 +11,23 @@ WITH base_swaps AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS recipient,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [0] :: STRING
         ) :: FLOAT AS amount0_unadj,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [1] :: STRING
         ) :: FLOAT AS amount1_unadj,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [2] :: STRING
         ) :: FLOAT AS sqrtPriceX96,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [3] :: STRING
         ) :: FLOAT AS liquidity,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [4] :: STRING
         ) :: FLOAT AS tick


### PR DESCRIPTION
- Update all models using hex_to_int using `public` or `ethereum.public` schema to `utils` schema
- Excludes models with `enabled = false`
- `models/silver/dex/pancake/silver_dex__pancakeswap_v2_amm_swaps.sql` was throwing an error due to `TRY_TO_NUMBER`
    - Removed ` :: INTEGER`  after `TRY_TO_NUMBER` function in `swap_base` CTE. This resolved the error.
- Was having issues running models with `ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION` post hook
    - After setting all post hooks from `ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION`  to `""` all models ran successfully
    - Did not commit post_hook modifications, only used for testing