### PR TITLE
remove null tokenid

### DIFF
--- a/models/silver/nft/silver_nft__complete_nft_sales.sql
+++ b/models/silver/nft/silver_nft__complete_nft_sales.sql
@@ -516,6 +516,7 @@ metadata AS (
         {{ ref('silver__nft_labels_temp') }}
     WHERE
         project_address IS NOT NULL
+        AND token_id IS NOT NULL
 ),
 prices_raw AS (
     SELECT


### PR DESCRIPTION
Removed null tokenid duplicates in the silver__nft_labels_temp table that causes duplicates in the complete nft sales table 