### PR TITLE
erc1155 fix 

### DIFF
--- a/models/gold/nft/core__ez_nft_transfers.sql
+++ b/models/gold/nft/core__ez_nft_transfers.sql
@@ -19,8 +19,5 @@ SELECT
     token_metadata,
     erc1155_value
 FROM
-    {{ ref('silver__nft_transfers') }} n 
+    {{ ref('silver__nft_transfers') }} 
 
-
-
-    -- left join  (select * rename address as contract_address from {{ ref('silver__contracts') }} ) using (contract_address)

--- a/models/silver/nft/silver_nft__complete_nft_sales.sql
+++ b/models/silver/nft/silver_nft__complete_nft_sales.sql
@@ -709,7 +709,8 @@ final_base AS (
         CASE
             WHEN currency_address IN (
                 'ETH',
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                '0x0000000000a39bb272e79075ade125fd351887ac'
             ) THEN total_price_raw / pow(
                 10,
                 18
@@ -724,7 +725,8 @@ final_base AS (
         CASE
             WHEN currency_address IN (
                 'ETH',
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                '0x0000000000a39bb272e79075ade125fd351887ac'
             ) THEN total_fees_raw / pow(
                 10,
                 18
@@ -739,7 +741,8 @@ final_base AS (
         CASE
             WHEN currency_address IN (
                 'ETH',
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                '0x0000000000a39bb272e79075ade125fd351887ac'
             ) THEN platform_fee_raw / pow(
                 10,
                 18
@@ -754,7 +757,8 @@ final_base AS (
         CASE
             WHEN currency_address IN (
                 'ETH',
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                '0x0000000000a39bb272e79075ade125fd351887ac'
             ) THEN creator_fee_raw / pow(
                 10,
                 18
@@ -844,6 +848,7 @@ label_fill_sales AS (
         ON t.nft_address = C.address
     WHERE
         t.project_name IS NULL
+        AND C.name IS NOT NULL
 )
 {% endif %},
 final_joins AS (


### PR DESCRIPTION
1. Cast erc1155 as string in nft transfers 
2. Improving complete nft sale incremental run times 
3. Added blurEth manual decimals adjustment in complete nft sales 
4. Removed ref to silver nft transfers in seaport 1.1 