### PR TITLE
fix/retry-missing-receipts

### DIFF
--- a/models/streamline/silver/core/retry/_missing_receipts.sql
+++ b/models/streamline/silver/core/retry/_missing_receipts.sql
@@ -29,4 +29,6 @@ WHERE
             lookback
     )
     AND t.block_timestamp >= DATEADD('hour', -84, SYSDATE())
-    AND r._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())
+    AND (
+        r._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())
+        OR r._inserted_timestamp IS NULL)


### PR DESCRIPTION
Adds filter to capture null _inserted_timestamp on missing receipts