### PR TITLE
AN-3995/optimize-univ3-views

### DIFF
--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.sql
@@ -43,6 +43,12 @@ token_prices AS (
             FROM
                 {{ ref('silver__univ3_lp_actions') }} 
         )
+                AND 
+            (
+                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
+            OR
+                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
+            )
 ),
 
 FINAL AS (

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.sql
@@ -12,97 +12,6 @@
     }
 ) }}
 
-WITH uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                {{ ref('silver__univ3_lp_actions') }} 
-        )
-                AND 
-            (
-                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
-            OR
-                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
-            )
-),
-
-FINAL AS (
-SELECT
-    'ethereum' AS blockchain,
-    block_number,
-    block_timestamp,
-    tx_hash,
-    action,
-    amount0 / pow(
-        10,
-        token0_decimals
-    ) AS amount0_adjusted,
-    amount1 / pow(
-        10,
-        token1_decimals
-    ) AS amount1_adjusted,
-    amount0_adjusted * p0.price AS amount0_usd,
-    amount1_adjusted * p1.price AS amount1_usd, 
-    a.token0_address,
-    a.token1_address,
-    token0_symbol,
-    token1_symbol,
-    p0.price AS token0_price,
-    p1.price AS token1_price,
-    liquidity,
-    liquidity / pow(10, (token1_decimals + token0_decimals) / 2) AS liquidity_adjusted,
-    liquidity_provider,
-    nf_position_manager_address,
-    nf_token_id,
-    a.pool_address,
-    pool_name,
-    tick_lower,
-    tick_upper,
-    pow(1.0001, (tick_lower)) / pow(10,(token1_decimals - token0_decimals)) AS price_lower_1_0,
-    pow(1.0001, (tick_upper)) / pow(10,(token1_decimals - token0_decimals)) AS price_upper_1_0, 
-    pow(1.0001, -1 * (tick_upper)) / pow(10,(token0_decimals - token1_decimals)) AS price_lower_0_1, 
-    pow(1.0001, -1 * (tick_lower)) / pow(10,(token0_decimals - token1_decimals)) AS price_upper_0_1, 
-    price_lower_1_0 * p1.price AS price_lower_1_0_usd, 
-    price_upper_1_0 * p1.price AS price_upper_1_0_usd, 
-    price_lower_0_1 * p0.price AS price_lower_0_1_usd, 
-    price_upper_0_1 * p0.price AS price_upper_0_1_usd
-FROM
-    {{ ref('silver__univ3_lp_actions') }} a
-INNER JOIN uni_pools p
-    ON a.pool_address = p.pool_address
-LEFT JOIN token_prices p0
-    ON p0.token_address = a.token0_address
-        AND p0.hour = DATE_TRUNC('hour',block_timestamp)
-LEFT JOIN token_prices p1
-    ON p1.token_address = a.token1_address
-        AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-)
-
 SELECT
     blockchain,
     block_number,
@@ -136,4 +45,5 @@ SELECT
     price_upper_1_0_usd,
     price_lower_0_1_usd,
     price_upper_0_1_usd
-FROM FINAL
+FROM
+    {{ ref('silver__univ3_lp_actions') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.yml
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_lp_actions.yml
@@ -16,18 +16,8 @@ models:
         description: '{{ doc("lp_actions_action") }}'
       - name: AMOUNT0_ADJUSTED
         description: '{{ doc("swaps_amount0_adjusted") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: AMOUNT1_ADJUSTED
         description: '{{ doc("swaps_amount1_adjusted") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: AMOUNT0_USD
         description: '{{ doc("swaps_amount0_usd") }}'
       - name: AMOUNT1_USD
@@ -48,11 +38,6 @@ models:
         description: '{{ doc("all_liquidity") }}'
       - name: LIQUIDITY_ADJUSTED
         description: '{{ doc("all_liquidity_adjusted") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: LIQUIDITY_PROVIDER
         description: '{{ doc("positions_liquidity_provider") }}'
       - name: NF_POSITION_MANAGER_ADDRESS

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.sql
@@ -6,110 +6,6 @@
     'PURPOSE': 'DEFI, DEX' } } }
 ) }}
 
-WITH uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                {{ ref('silver__univ3_pool_stats') }} 
-        )
-        AND 
-            (
-                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
-            OR
-                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
-            )
-),
-
-FINAL AS (
-SELECT
-    'ethereum' AS blockchain,
-    block_number,
-    block_timestamp,
-    feeGrowthGlobal0X128 AS fee_growth_global0_x128,
-    feeGrowthGlobal1X128 AS fee_growth_global1_x128,
-    a.pool_address,
-    pool_name,
-    pow(1.0001,tick) / pow(10,token1_decimals - token0_decimals
-        ) AS price_1_0,
-    1 / price_1_0 AS price_0_1,
-    COALESCE(
-        token0_protocol_fees / pow(10,token0_decimals),
-        0
-        ) AS protocol_fees_token0_adjusted, 
-    COALESCE(
-        token1_protocol_fees / pow(10,token1_decimals),
-        0
-        ) AS protocol_fees_token1_adjusted,
-    a.token0_address,
-    a.token1_address,
-    token0_symbol,
-    token1_symbol,
-    tick,
-    unlocked,
-    COALESCE(
-        liquidity / pow(10,(token1_decimals + token0_decimals) / 2),
-        0
-        ) AS virtual_liquidity_adjusted,
-    div0(
-        liquidity,
-        sqrt_hp
-    ) / pow(
-        10,
-        token0_decimals
-        ) AS virtual_reserves_token0_adjusted,
-    (
-        liquidity * sqrt_hp
-    ) / pow(
-        10,
-        token1_decimals
-        ) AS virtual_reserves_token1_adjusted,
-    virtual_reserves_token0_adjusted * p0.price AS virtual_reserves_token0_usd,
-    virtual_reserves_token1_adjusted * p1.price AS virtual_reserves_token1_usd,
-    token0_balance,
-    token1_balance,
-    token0_balance / pow(10,token0_decimals
-        ) AS token0_balance_adjusted,
-    token1_balance / pow(10,token1_decimals
-        ) AS token1_balance_adjusted,
-    token0_balance_adjusted * p0.price AS token0_balance_usd,
-    token1_balance_adjusted * p1.price AS token1_balance_usd
-FROM
-    {{ ref('silver__univ3_pool_stats') }} a
-LEFT JOIN uni_pools p
-    ON a.pool_address = p.pool_address
-LEFT JOIN token_prices p0
-    ON p0.token_address = a.token0_address
-        AND p0.hour = DATE_TRUNC('hour',block_timestamp)
-LEFT JOIN token_prices p1
-    ON p1.token_address = a.token1_address
-        AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-)
-
 SELECT
     blockchain,
     block_number,
@@ -139,4 +35,5 @@ SELECT
     token1_balance_usd,
     token0_balance,
     token1_balance
-FROM FINAL
+FROM 
+    {{ ref('silver__univ3_pool_stats') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.sql
@@ -37,6 +37,12 @@ token_prices AS (
             FROM
                 {{ ref('silver__univ3_pool_stats') }} 
         )
+        AND 
+            (
+                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
+            OR
+                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
+            )
 ),
 
 FINAL AS (

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.yml
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pool_stats.yml
@@ -40,12 +40,6 @@ models:
         description: '{{ doc("pool_stats_unlocked") }}'
       - name: VIRTUAL_LIQUIDITY_ADJUSTED
         description: '{{ doc("pool_stats_virtual_liquidity_adjusted") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: VIRTUAL_RESERVES_TOKEN0_ADJUSTED
         description: '{{ doc("pool_stats_virtual_reserves_token0_adjusted") }}'
       - name: VIRTUAL_RESERVES_TOKEN1_ADJUSTED

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
@@ -12,91 +12,6 @@
     }
 ) }}
 
-{# WITH contracts AS (
-    SELECT
-        LOWER(address) AS address,
-        symbol,
-        NAME,
-        decimals
-    FROM
-        {{ ref('silver__contracts') }}
-    WHERE
-        decimals IS NOT NULL
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT created_time :: DATE
-            FROM
-                {{ ref('silver__univ3_pools') }} 
-        )
-),
-
-FINAL AS (
-
-SELECT
-    'ethereum' AS blockchain,
-    created_block AS block_number,
-    created_time AS block_timestamp,
-    created_tx_hash AS tx_hash,
-    '0x1f98431c8ad98523631ae4a59f267346ea31f984' AS factory_address,
-    token0_address,
-    token1_address,
-    c0.symbol AS token0_symbol,
-    c1.symbol AS token1_symbol,
-    c0.name AS token0_name,
-    c1.name AS token1_name,
-    c0.decimals AS token0_decimals,
-    c1.decimals AS token1_decimals,
-    p0.price AS token0_price,
-    p1.price AS token1_price,
-    fee,
-    fee_percent,
-    COALESCE(
-        init_price_1_0_unadj / pow(
-            10,
-            token1_decimals - token0_decimals
-        ),
-        0
-    ) AS init_price_1_0,
-    init_price_1_0 * token1_price AS init_price_1_0_usd,
-    init_tick,
-    tick_spacing,
-    div0(
-        token1_price,
-        token0_price
-    ) AS usd_ratio,
-    pool_address,
-    CONCAT(
-        token0_symbol,
-        '-',
-        token1_symbol,
-        ' ',
-        fee,
-        ' ',
-        tick_spacing
-    ) AS pool_name
-FROM {{ ref('silver__univ3_pools') }} p 
-LEFT JOIN contracts c0
-    ON c0.address = p.token0_address
-LEFT JOIN contracts c1
-    ON c1.address = p.token1_address
-LEFT JOIN token_prices p0
-    ON p0.token_address = p.token0_address
-    AND p0.hour = DATE_TRUNC('hour',created_time)
-LEFT JOIN token_prices p1
-    ON p1.token_address = p.token1_address
-    AND p1.hour = DATE_TRUNC('hour',created_time)
-) #}
-
 SELECT
     blockchain,
     block_number,
@@ -119,4 +34,5 @@ SELECT
     token1_name,
     token0_decimals,
     token1_decimals    
-FROM {{ ref('silver__univ3_pools') }}
+FROM 
+    {{ ref('silver__univ3_pools') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
@@ -12,7 +12,7 @@
     }
 ) }}
 
-WITH contracts AS (
+{# WITH contracts AS (
     SELECT
         LOWER(address) AS address,
         symbol,
@@ -95,7 +95,7 @@ LEFT JOIN token_prices p0
 LEFT JOIN token_prices p1
     ON p1.token_address = p.token1_address
     AND p1.hour = DATE_TRUNC('hour',created_time)
-)
+) #}
 
 SELECT
     blockchain,
@@ -119,4 +119,4 @@ SELECT
     token1_name,
     token0_decimals,
     token1_decimals    
-FROM FINAL
+FROM {{ ref('silver__univ3_pools') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.sql
@@ -14,9 +14,9 @@
 
 SELECT
     blockchain,
-    block_number,
-    block_timestamp,
-    tx_hash,
+    created_block AS block_number,
+    created_time AS block_timestamp,
+    created_tx_hash AS tx_hash,
     factory_address,
     fee,
     fee_percent,

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.yml
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_pools.yml
@@ -2,10 +2,6 @@ version: 2
 models:
   - name: uniswapv3__ez_pools
     description: '{{ doc("pools_table_doc") }}' 
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - POOL_ADDRESS
     columns:
       - name: BLOCKCHAIN
         description: '{{ doc("eth_blockchain") }}'    
@@ -23,12 +19,6 @@ models:
         description: '{{ doc("pools_fee") }}'
       - name: INIT_PRICE_1_0
         description: '{{ doc("pools_init_price_1_0") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: INIT_PRICE_1_0_USD
         description: '{{ doc("pools_init_price_1_0_usd") }}'     
       - name: INIT_TICK

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_position_collected_fees.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_position_collected_fees.sql
@@ -12,81 +12,6 @@
     }
 ) }}
 
-WITH uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                {{ ref('silver__univ3_position_collected_fees') }} 
-        )
-        AND 
-            (
-                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
-            OR
-                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
-            )
-),
-
-FINAL AS (
-SELECT
-    blockchain,
-    block_number,
-    block_timestamp,
-    tx_hash,
-    event_index,
-    a.pool_address,
-    pool_name,
-    liquidity_provider,
-    nf_token_id,
-    nf_position_manager_address,
-    token0_symbol,
-    token1_symbol,
-    amount0 / pow(10,token0_decimals) AS amount0_adjusted,
-    amount1 / pow(10,token1_decimals) AS amount1_adjusted,
-    ROUND(amount0_adjusted * p0.price,2) AS amount0_usd,
-    ROUND(amount1_adjusted * p1.price,2) AS amount1_usd,
-    tick_lower,
-    tick_upper,
-    pow(1.0001,tick_lower) / pow(10,(token1_decimals - token0_decimals)) AS price_lower,
-    pow(1.0001,tick_upper) / pow(10,(token1_decimals - token0_decimals)) AS price_upper,
-    ROUND(price_lower * p1.price,2) AS price_lower_usd,
-    ROUND(price_upper * p1.price,2) AS price_upper_usd
-FROM
-    {{ ref('silver__univ3_position_collected_fees') }} a
-LEFT JOIN uni_pools p
-    ON a.pool_address = p.pool_address
-LEFT JOIN token_prices p0
-    ON p0.token_address = a.token0_address
-        AND p0.hour = DATE_TRUNC('hour',block_timestamp)
-LEFT JOIN token_prices p1
-    ON p1.token_address = a.token1_address
-        AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-)
-
 SELECT
     blockchain,
     block_number,
@@ -110,4 +35,5 @@ SELECT
     price_upper,
     price_lower_usd,
     price_upper_usd
-FROM FINAL
+FROM 
+    {{ ref('silver__univ3_position_collected_fees') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_position_collected_fees.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_position_collected_fees.sql
@@ -43,6 +43,12 @@ token_prices AS (
             FROM
                 {{ ref('silver__univ3_position_collected_fees') }} 
         )
+        AND 
+            (
+                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
+            OR
+                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
+            )
 ),
 
 FINAL AS (

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.sql
@@ -12,114 +12,6 @@
     }
 ) }}
 
-WITH uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                {{ ref('silver__univ3_lp_actions') }} 
-        )
-        AND 
-            (
-                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
-            OR
-                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
-            )
-),
-
-FINAL AS (
-
-SELECT
-    blockchain,
-    block_number,
-    block_timestamp,
-    tx_hash,
-    a.fee_percent,
-    fee_growth_inside0_last_x128,
-    fee_growth_inside1_last_x128,
-    is_active,
-    COALESCE(
-            liquidity / pow(10, (token1_decimals + token0_decimals) / 2),
-            0
-        ) AS liquidity_adjusted,
-    liquidity_provider,
-    nf_position_manager_address,
-    nf_token_id,
-    a.pool_address,
-    pool_name,
-    a.tick_upper,
-    a.tick_lower,
-    pow(1.0001, (tick_lower)) / pow(10,(token1_decimals - token0_decimals)) AS price_lower_1_0,
-    pow(1.0001, (tick_upper)) / pow(10,(token1_decimals - token0_decimals)) AS price_upper_1_0, 
-    pow(1.0001, -1 * (tick_upper)) / pow(10,(token0_decimals - token1_decimals)) AS price_lower_0_1, 
-    pow(1.0001, -1 * (tick_lower)) / pow(10,(token0_decimals - token1_decimals)) AS price_upper_0_1, 
-    price_lower_1_0 * p1.price AS price_lower_1_0_usd, 
-    price_upper_1_0 * p1.price AS price_upper_1_0_usd, 
-    price_lower_0_1 * p0.price AS price_lower_0_1_usd, 
-    price_upper_0_1 * p0.price AS price_upper_0_1_usd,
-    COALESCE(
-            tokensOwed0 / pow(
-                10,
-                token0_decimals
-            ),
-            0
-        ) AS tokens_owed0_adjusted,
-    COALESCE(
-            tokensOwed1 / pow(
-                10,
-                token1_decimals
-            ),
-            0
-        ) AS tokens_owed1_adjusted,
-    COALESCE(
-            tokens_owed0_adjusted * p0.price,
-            0
-        ) AS tokens_owed0_usd,
-    COALESCE(
-            tokens_owed1_adjusted * p1.price,
-            0
-        ) AS tokens_owed1_usd,
-    a.token0_address,
-    a.token1_address,
-    token0_symbol,
-    token1_symbol
-FROM
-    {{ ref('silver__univ3_positions') }} a
-LEFT JOIN uni_pools p
-    ON a.pool_address = p.pool_address
-LEFT JOIN token_prices p0
-    ON p0.token_address = a.token0_address
-        AND p0.hour = DATE_TRUNC('hour',block_timestamp)
-LEFT JOIN token_prices p1
-    ON p1.token_address = a.token1_address
-        AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-
-)
-
 SELECT
     blockchain,
     block_number,
@@ -153,4 +45,5 @@ SELECT
     token1_address,
     token0_symbol,
     token1_symbol
-FROM FINAL
+FROM
+    {{ ref('silver__univ3_positions') }}

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.sql
@@ -43,6 +43,12 @@ token_prices AS (
             FROM
                 {{ ref('silver__univ3_lp_actions') }} 
         )
+        AND 
+            (
+                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
+            OR
+                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
+            )
 ),
 
 FINAL AS (

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.yml
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_positions.yml
@@ -22,12 +22,6 @@ models:
         description: '{{ doc("positions_is_active") }}'
       - name: LIQUIDITY_ADJUSTED
         description: '{{ doc("all_liquidity_adjusted") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - decimal
-                - float
       - name: LIQUIDITY_PROVIDER
         description: '{{ doc("positions_liquidity_provider") }}'
       - name: NF_POSITION_MANAGER_ADDRESS
@@ -64,12 +58,8 @@ models:
         description: '{{ doc("positions_token_owed1_adjusted") }}'
       - name: TOKENS_OWED0_USD
         description: '{{ doc("positions_tokens_owed0_usd") }}'
-        tests:
-          - not_null
       - name: TOKENS_OWED1_USD
         description: '{{ doc("positions_tokens_owed1_usd") }}'
-        tests:
-          - not_null
       - name: TOKEN0_ADDRESS
         description: '{{ doc("all_token0_address") }}'
       - name: TOKEN1_ADDRESS

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
@@ -43,6 +43,12 @@ token_prices AS (
             FROM
                 {{ ref('silver__univ3_swaps') }} 
         )
+        AND 
+            (
+                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
+            OR
+                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
+            )
 ),
 
 FINAL AS (

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
@@ -12,107 +12,6 @@
     }
 ) }}
 
-{# WITH uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
-
-token_prices AS (
-    SELECT
-        HOUR,
-        LOWER(token_address) AS token_address,
-        price
-    FROM
-        {{ ref('price__ez_hourly_token_prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                {{ ref('silver__univ3_swaps') }} 
-        )
-        AND 
-            (
-                token_address in (SELECT DISTINCT(token0_address) from uni_pools)
-            OR
-                token_address in (SELECT DISTINCT(token1_address) from uni_pools)
-            )
-),
-
-FINAL AS (
-    SELECT
-        s.blockchain,
-        s.block_number,
-        s.block_timestamp,
-        s.tx_hash,
-        s.pool_address,
-        p.pool_name,
-        recipient,
-        sender,
-        tick,
-        liquidity,
-        COALESCE(
-            liquidity / pow(10,((token0_decimals + token1_decimals) / 2)),0
-                ) AS liquidity_adjusted,
-        event_index,
-        amount0_unadj / pow(
-            10,
-            COALESCE(
-                token0_decimals,
-                18
-            )
-        ) AS amount0_adjusted,
-        amount1_unadj / pow(
-            10,
-            COALESCE(
-                token1_decimals,
-                18
-            )
-        ) AS amount1_adjusted,
-        COALESCE(div0(ABS(amount1_adjusted), ABS(amount0_adjusted)), 0) AS price_1_0,
-        COALESCE(div0(ABS(amount0_adjusted), ABS(amount1_adjusted)), 0) AS price_0_1,
-        p0.price AS token0_price,
-        p1.price AS token1_price,
-        CASE
-            WHEN token0_decimals IS NOT NULL THEN ROUND(
-                token0_price * amount0_adjusted,
-                2
-            )
-        END AS amount0_usd,
-        CASE
-            WHEN token1_decimals IS NOT NULL THEN ROUND(
-                token1_price * amount1_adjusted,
-                2
-            )
-        END AS amount1_usd,
-        s.token0_address,
-        s.token1_address,
-        token0_symbol,
-        token1_symbol
-    FROM
-        {{ ref('silver__univ3_swaps') }} s 
-    LEFT JOIN uni_pools p
-        ON s.pool_address = p.pool_address
-    LEFT JOIN token_prices p0
-        ON p0.token_address = s.token0_address
-            AND p0.hour = DATE_TRUNC('hour',block_timestamp)
-    LEFT JOIN token_prices p1
-        ON p1.token_address = s.token1_address
-            AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-) #}
-
 SELECT
     blockchain,
     block_number,
@@ -139,4 +38,4 @@ SELECT
     amount0_usd,
     amount1_usd
 FROM
-    {{ ref('silver__univ3_swaps') }} s
+    {{ ref('silver__univ3_swaps') }} 

--- a/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
+++ b/models/gold/protocols/uniswapv3/uniswapv3__ez_swaps.sql
@@ -12,7 +12,7 @@
     }
 ) }}
 
-WITH uni_pools AS (
+{# WITH uni_pools AS (
     SELECT
         token0_address,
         token1_address,
@@ -111,7 +111,7 @@ FINAL AS (
     LEFT JOIN token_prices p1
         ON p1.token_address = s.token1_address
             AND p1.hour = DATE_TRUNC('hour',block_timestamp)
-)
+) #}
 
 SELECT
     blockchain,
@@ -139,4 +139,4 @@ SELECT
     amount0_usd,
     amount1_usd
 FROM
-    FINAL
+    {{ ref('silver__univ3_swaps') }} s

--- a/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
@@ -45,7 +45,6 @@ uni_pools AS (
     FROM
         {{ ref('silver__univ3_pools') }}
 ),
-
 -- pulls info for increases or decreases (mint / burn events) in liquidity
 lp_amounts AS (
     SELECT
@@ -69,9 +68,9 @@ lp_amounts AS (
             topics [2] :: STRING
         ) :: FLOAT AS tick_lower,
         utils.udf_hex_to_int(
-                's2c', 
-                topics [3] :: STRING
-            ) :: FLOAT AS tick_upper,
+            's2c',
+            topics [3] :: STRING
+        ) :: FLOAT AS tick_upper,
         CASE
             WHEN topics [0] :: STRING = '0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde' THEN utils.udf_hex_to_int(
                 's2c',
@@ -163,7 +162,6 @@ nf_info AS (
             '0x26f6a048ee9138f2c0ce266f322cb99228e8d619ae2bff30c67f8dcf9d2377b4'
         )
 ),
-
 FINAL AS (
     SELECT
         blockchain,
@@ -195,11 +193,109 @@ FINAL AS (
         AND A.amount0 = C.amount0
         AND A.amount1 = C.amount1
         AND A.agg_id = C.agg_id
-)
+),
+silver_lp_actions AS (
+    SELECT
+        *
+    FROM
+        FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
+    ORDER BY
+        _inserted_timestamp DESC)) = 1
+),
+uni_pools_2 AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
+    FROM
+        {{ ref('uniswapv3__ez_pools') }}
+),
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                silver_lp_actions
+        )
 
+{% if is_incremental() %}
+AND HOUR >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
 SELECT
-    *
+    'ethereum' AS blockchain,
+    block_number,
+    block_timestamp,
+    tx_hash,
+    action,
+    amount0 / pow(
+        10,
+        token0_decimals
+    ) AS amount0_adjusted,
+    amount1 / pow(
+        10,
+        token1_decimals
+    ) AS amount1_adjusted,
+    amount0_adjusted * p0.price AS amount0_usd,
+    amount1_adjusted * p1.price AS amount1_usd,
+    A.token0_address,
+    A.token1_address,
+    token0_symbol,
+    token1_symbol,
+    p0.price AS token0_price,
+    p1.price AS token1_price,
+    liquidity,
+    liquidity / pow(10, (token1_decimals + token0_decimals) / 2) AS liquidity_adjusted,
+    liquidity_provider,
+    nf_position_manager_address,
+    nf_token_id,
+    A.pool_address,
+    pool_name,
+    tick_lower,
+    tick_upper,
+    pow(1.0001, (tick_lower)) / pow(10,(token1_decimals - token0_decimals)) AS price_lower_1_0,
+    pow(1.0001, (tick_upper)) / pow(10,(token1_decimals - token0_decimals)) AS price_upper_1_0,
+    pow(1.0001, -1 * (tick_upper)) / pow(10,(token0_decimals - token1_decimals)) AS price_lower_0_1,
+    pow(1.0001, -1 * (tick_lower)) / pow(10,(token0_decimals - token1_decimals)) AS price_upper_0_1,
+    price_lower_1_0 * p1.price AS price_lower_1_0_usd,
+    price_upper_1_0 * p1.price AS price_upper_1_0_usd,
+    price_lower_0_1 * p0.price AS price_lower_0_1_usd,
+    price_upper_0_1 * p0.price AS price_upper_0_1_usd,
+    _log_id,
+    _inserted_timestamp
 FROM
-    FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
-ORDER BY
-    _inserted_timestamp DESC)) = 1
+    silver_lp_actions A
+    INNER JOIN uni_pools_2 p
+    ON A.pool_address = p.pool_address
+    LEFT JOIN token_prices p0
+    ON p0.token_address = A.token0_address
+    AND p0.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )
+    LEFT JOIN token_prices p1
+    ON p1.token_address = A.token1_address
+    AND p1.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )

--- a/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
@@ -28,7 +28,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -221,15 +221,6 @@ token_prices AS (
             FROM
                 silver_lp_actions
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
-    FROM
-        {{ this }}
-)
-{% endif %}
 )
 SELECT
     'ethereum' AS blockchain,

--- a/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.sql
@@ -41,7 +41,12 @@ uni_pools AS (
         fee,
         fee_percent,
         tick_spacing,
-        pool_address
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
     FROM
         {{ ref('silver__univ3_pools') }}
 ),
@@ -202,22 +207,6 @@ silver_lp_actions AS (
     ORDER BY
         _inserted_timestamp DESC)) = 1
 ),
-uni_pools_2 AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
 token_prices AS (
     SELECT
         HOUR,
@@ -285,7 +274,7 @@ SELECT
     _inserted_timestamp
 FROM
     silver_lp_actions A
-    INNER JOIN uni_pools_2 p
+    INNER JOIN uni_pools p
     ON A.pool_address = p.pool_address
     LEFT JOIN token_prices p0
     ON p0.token_address = A.token0_address

--- a/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.yml
+++ b/models/silver/protocols/uniswapv3/silver__univ3_lp_actions.yml
@@ -18,9 +18,27 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
+      - name: AMOUNT0_ADJUSTED
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: AMOUNT1_ADJUSTED
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
       - name: BLOCKCHAIN
         tests:
           - not_null
+      - name: LIQUIDITY_ADJUSTED
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
       - name: LIQUIDITY_PROVIDER
         tests:
           - not_null

--- a/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
@@ -36,7 +36,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        )  - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -322,15 +322,6 @@ token_prices AS (
             FROM
                 silver_pool_stats
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
-    FROM
-        {{ this }}
-)
-{% endif %}
 )
 SELECT
     'ethereum' AS blockchain,

--- a/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
@@ -255,50 +255,157 @@ max_balances AS (
         token_balances qualify(ROW_NUMBER() over(PARTITION BY address, contract_address
     ORDER BY
         block_hour DESC)) = 1
+),
+silver_pool_stats as (
+    SELECT
+        A.*,
+        COALESCE(
+            b0.balance,
+            db0.daily_balance,
+            mb0.max_balance,
+            0
+        ) AS token0_balance,
+        COALESCE(
+            b1.balance,
+            db1.daily_balance,
+            mb1.max_balance,
+            0
+        ) AS token1_balance
+    FROM
+        join_meta A
+        LEFT JOIN token_balances AS b0
+        ON A.pool_address = b0.address
+        AND A.token0_address = b0.contract_address
+        AND DATE_TRUNC(
+            'hour',
+            A.block_timestamp
+        ) = b0.block_hour
+        LEFT JOIN token_balances AS b1
+        ON A.pool_address = b1.address
+        AND A.token1_address = b1.contract_address
+        AND DATE_TRUNC(
+            'hour',
+            A.block_timestamp
+        ) = b1.block_hour
+        LEFT JOIN daily_balances db0
+        ON A.pool_address = db0.address
+        AND A.token0_address = db0.contract_address
+        AND A.block_timestamp :: DATE = db0.block_date
+        LEFT JOIN daily_balances db1
+        ON A.pool_address = db1.address
+        AND A.token1_address = db1.contract_address
+        AND A.block_timestamp :: DATE = db1.block_date
+        LEFT JOIN max_balances mb0
+        ON A.pool_address = mb0.address
+        AND A.token0_address = mb0.contract_address
+        LEFT JOIN max_balances mb1
+        ON A.pool_address = mb1.address
+        AND A.token1_address = mb1.contract_address qualify(ROW_NUMBER() over(PARTITION BY id
+    ORDER BY
+        A._inserted_timestamp DESC)) = 1
+),
+uni_pools AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
+    FROM
+        {{ ref('uniswapv3__ez_pools') }}
+),
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                silver_pool_stats 
+        )
+{% if is_incremental() %}
+AND HOUR >= (
+  SELECT
+    MAX(_inserted_timestamp) :: DATE - 2
+  FROM
+    {{ this }}
 )
-SELECT
-    A.*,
-    COALESCE(
-        b0.balance,
-        db0.daily_balance,
-        mb0.max_balance,
-        0
-    ) AS token0_balance,
-    COALESCE(
-        b1.balance,
-        db1.daily_balance,
-        mb1.max_balance,
-        0
-    ) AS token1_balance
-FROM
-    join_meta A
-    LEFT JOIN token_balances AS b0
-    ON A.pool_address = b0.address
-    AND A.token0_address = b0.contract_address
-    AND DATE_TRUNC(
-        'hour',
-        A.block_timestamp
-    ) = b0.block_hour
-    LEFT JOIN token_balances AS b1
-    ON A.pool_address = b1.address
-    AND A.token1_address = b1.contract_address
-    AND DATE_TRUNC(
-        'hour',
-        A.block_timestamp
-    ) = b1.block_hour
-    LEFT JOIN daily_balances db0
-    ON A.pool_address = db0.address
-    AND A.token0_address = db0.contract_address
-    AND A.block_timestamp :: DATE = db0.block_date
-    LEFT JOIN daily_balances db1
-    ON A.pool_address = db1.address
-    AND A.token1_address = db1.contract_address
-    AND A.block_timestamp :: DATE = db1.block_date
-    LEFT JOIN max_balances mb0
-    ON A.pool_address = mb0.address
-    AND A.token0_address = mb0.contract_address
-    LEFT JOIN max_balances mb1
-    ON A.pool_address = mb1.address
-    AND A.token1_address = mb1.contract_address qualify(ROW_NUMBER() over(PARTITION BY id
-ORDER BY
-    A._inserted_timestamp DESC)) = 1
+{% endif %}
+)
+
+    SELECT
+        'ethereum' AS blockchain,
+        block_number,
+        block_timestamp,
+        feeGrowthGlobal0X128 AS fee_growth_global0_x128,
+        feeGrowthGlobal1X128 AS fee_growth_global1_x128,
+        a.pool_address,
+        pool_name,
+        pow(1.0001,tick) / pow(10,token1_decimals - token0_decimals
+            ) AS price_1_0,
+        1 / price_1_0 AS price_0_1,
+        COALESCE(
+            token0_protocol_fees / pow(10,token0_decimals),
+            0
+            ) AS protocol_fees_token0_adjusted, 
+        COALESCE(
+            token1_protocol_fees / pow(10,token1_decimals),
+            0
+            ) AS protocol_fees_token1_adjusted,
+        a.token0_address,
+        a.token1_address,
+        token0_symbol,
+        token1_symbol,
+        tick,
+        unlocked,
+        COALESCE(
+            liquidity / pow(10,(token1_decimals + token0_decimals) / 2),
+            0
+            ) AS virtual_liquidity_adjusted,
+        div0(
+            liquidity,
+            sqrt_hp
+        ) / pow(
+            10,
+            token0_decimals
+            ) AS virtual_reserves_token0_adjusted,
+        (
+            liquidity * sqrt_hp
+        ) / pow(
+            10,
+            token1_decimals
+            ) AS virtual_reserves_token1_adjusted,
+        virtual_reserves_token0_adjusted * p0.price AS virtual_reserves_token0_usd,
+        virtual_reserves_token1_adjusted * p1.price AS virtual_reserves_token1_usd,
+        token0_balance,
+        token1_balance,
+        token0_balance / pow(10,token0_decimals
+            ) AS token0_balance_adjusted,
+        token1_balance / pow(10,token1_decimals
+            ) AS token1_balance_adjusted,
+        token0_balance_adjusted * p0.price AS token0_balance_usd,
+        token1_balance_adjusted * p1.price AS token1_balance_usd,
+        id,
+        _inserted_timestamp
+    FROM
+        silver_pool_stats a
+    LEFT JOIN uni_pools p
+        ON a.pool_address = p.pool_address
+    LEFT JOIN token_prices p0
+        ON p0.token_address = a.token0_address
+            AND p0.hour = DATE_TRUNC('hour',block_timestamp)
+    LEFT JOIN token_prices p1
+        ON p1.token_address = a.token1_address
+            AND p1.hour = DATE_TRUNC('hour',block_timestamp)
+

--- a/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.sql
@@ -46,10 +46,14 @@ pool_meta AS (
     SELECT
         token0_address,
         token1_address,
-        fee,
         fee_percent,
         tick_spacing,
-        pool_address
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
     FROM
         {{ ref('silver__univ3_pools') }}
 ),
@@ -304,22 +308,6 @@ silver_pool_stats as (
     ORDER BY
         A._inserted_timestamp DESC)) = 1
 ),
-uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
-),
 token_prices AS (
     SELECT
         HOUR,
@@ -400,7 +388,7 @@ AND HOUR >= (
         _inserted_timestamp
     FROM
         silver_pool_stats a
-    LEFT JOIN uni_pools p
+    LEFT JOIN pool_meta p
         ON a.pool_address = p.pool_address
     LEFT JOIN token_prices p0
         ON p0.token_address = a.token0_address

--- a/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.yml
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pool_stats.yml
@@ -24,6 +24,13 @@ models:
         tests:
           - not_null:
               enabled: False
+      - name: VIRTUAL_LIQUIDITY_ADJUSTED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
       - name: POOL_ADDRESS
         tests:
           - not_null

--- a/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
@@ -66,27 +66,144 @@ AND _inserted_timestamp >= (
         {{ this }}
 )
 {% endif %}
-)
+),
+silver_pools as (
+    SELECT
+        created_block,
+        created_time,
+        created_tx_hash,
+        token0_address,
+        token1_address,
+        fee :: INTEGER AS fee,
+        (
+            fee / 10000
+        ) :: FLOAT AS fee_percent,
+        tick_spacing,
+        pool_address,
+        init_sqrtPriceX96,
+        COALESCE(
+            init_tick,
+            0
+        ) AS init_tick,
+        init_price_1_0_unadj,
+        _inserted_timestamp
+    FROM created_pools
+    LEFT JOIN initial_info
+        ON pool_address = contract_address
+),
+contracts AS (
+    SELECT
+        LOWER(address) AS address,
+        symbol,
+        NAME,
+        decimals
+    FROM
+        {{ ref('silver__contracts') }}
+    WHERE
+        decimals IS NOT NULL
+        AND 
+            (
+                address in (SELECT DISTINCT(token0_address) from silver_pools)
+            OR
+                address in (SELECT DISTINCT(token1_address) from silver_pools)
+            )
+            
+),
+
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT created_time :: DATE
+            FROM
+                silver_pools 
+        )
+),
+
+FINAL AS (
 
 SELECT
-    created_block,
-    created_time,
-    created_tx_hash,
+    'ethereum' AS blockchain,
+    created_block AS block_number,
+    created_time AS block_timestamp,
+    created_tx_hash AS tx_hash,
+    '0x1f98431c8ad98523631ae4a59f267346ea31f984' AS factory_address,
     token0_address,
     token1_address,
-    fee :: INTEGER AS fee,
-    (
-        fee / 10000
-    ) :: FLOAT AS fee_percent,
-    tick_spacing,
-    pool_address,
-    init_sqrtPriceX96,
+    c0.symbol AS token0_symbol,
+    c1.symbol AS token1_symbol,
+    c0.name AS token0_name,
+    c1.name AS token1_name,
+    c0.decimals AS token0_decimals,
+    c1.decimals AS token1_decimals,
+    p0.price AS token0_price,
+    p1.price AS token1_price,
+    fee,
+    fee_percent,
     COALESCE(
-        init_tick,
+        init_price_1_0_unadj / pow(
+            10,
+            token1_decimals - token0_decimals
+        ),
         0
-    ) AS init_tick,
-    init_price_1_0_unadj,
+    ) AS init_price_1_0,
+    init_price_1_0 * token1_price AS init_price_1_0_usd,
+    init_tick,
+    tick_spacing,
+    div0(
+        token1_price,
+        token0_price
+    ) AS usd_ratio,
+    pool_address,
+    CONCAT(
+        token0_symbol,
+        '-',
+        token1_symbol,
+        ' ',
+        fee,
+        ' ',
+        tick_spacing
+    ) AS pool_name,
     _inserted_timestamp
-FROM created_pools
-LEFT JOIN initial_info
-    ON pool_address = contract_address
+FROM silver_pools p 
+LEFT JOIN contracts c0
+    ON c0.address = p.token0_address
+LEFT JOIN contracts c1
+    ON c1.address = p.token1_address
+LEFT JOIN token_prices p0
+    ON p0.token_address = p.token0_address
+    AND p0.hour = DATE_TRUNC('hour',created_time)
+LEFT JOIN token_prices p1
+    ON p1.token_address = p.token1_address
+    AND p1.hour = DATE_TRUNC('hour',created_time)
+)
+SELECT
+    blockchain,
+    block_number,
+    block_timestamp,
+    tx_hash,
+    factory_address,
+    fee,
+    fee_percent,
+    init_price_1_0,
+    init_price_1_0_usd,
+    init_tick,
+    pool_address,
+    pool_name,
+    tick_spacing,
+    token0_address,
+    token1_address,
+    token0_symbol,
+    token1_symbol,
+    token0_name,
+    token1_name,
+    token0_decimals,
+    token1_decimals,
+    _inserted_timestamp    
+FROM FINAL

--- a/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
@@ -35,7 +35,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -61,7 +61,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -101,13 +101,6 @@ contracts AS (
         {{ ref('silver__contracts') }}
     WHERE
         decimals IS NOT NULL
-        AND 
-            (
-                address in (SELECT DISTINCT(token0_address) from silver_pools)
-            OR
-                address in (SELECT DISTINCT(token1_address) from silver_pools)
-            )
-            
 ),
 
 token_prices AS (

--- a/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
@@ -127,9 +127,9 @@ token_prices AS (
 )
 SELECT
     'ethereum' AS blockchain,
-    created_block AS block_number,
-    created_time AS block_timestamp,
-    created_tx_hash AS tx_hash,
+    created_block,
+    created_time,
+    created_tx_hash,
     '0x1f98431c8ad98523631ae4a59f267346ea31f984' AS factory_address,
     token0_address,
     token1_address,

--- a/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pools.sql
@@ -124,10 +124,7 @@ token_prices AS (
             FROM
                 silver_pools 
         )
-),
-
-FINAL AS (
-
+)
 SELECT
     'ethereum' AS blockchain,
     created_block AS block_number,
@@ -182,28 +179,3 @@ LEFT JOIN token_prices p0
 LEFT JOIN token_prices p1
     ON p1.token_address = p.token1_address
     AND p1.hour = DATE_TRUNC('hour',created_time)
-)
-SELECT
-    blockchain,
-    block_number,
-    block_timestamp,
-    tx_hash,
-    factory_address,
-    fee,
-    fee_percent,
-    init_price_1_0,
-    init_price_1_0_usd,
-    init_tick,
-    pool_address,
-    pool_name,
-    tick_spacing,
-    token0_address,
-    token1_address,
-    token0_symbol,
-    token1_symbol,
-    token0_name,
-    token1_name,
-    token0_decimals,
-    token1_decimals,
-    _inserted_timestamp    
-FROM FINAL

--- a/models/silver/protocols/uniswapv3/silver__univ3_pools.yml
+++ b/models/silver/protocols/uniswapv3/silver__univ3_pools.yml
@@ -23,6 +23,13 @@ models:
                 - decimal
                 - float
                 - number
+      - name: INIT_PRICE_1_0
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
       - name: INIT_TICK
         tests:
           - not_null

--- a/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
@@ -93,33 +93,136 @@ pool_data AS (
         pool_address
     FROM
         {{ ref('silver__univ3_pools') }}
+),
+silver_positions AS (
+    SELECT
+        'ethereum' AS blockchain,
+        b.block_number AS block_number,
+        b.block_timestamp AS block_timestamp,
+        b.tx_hash AS tx_hash,
+        b.event_index AS event_index,
+        b.contract_address AS pool_address,
+        b.origin_from_address AS liquidity_provider,
+        nf_token_id,
+        CASE
+            WHEN nf_token_id IS NULL THEN vault_address
+            ELSE nf_position_manager_address
+        END AS nf_position_manager_address,
+        token0_address,
+        token1_address,
+        b.amount0,
+        b.amount1,
+        b.tick_lower,
+        b.tick_upper,
+        _inserted_timestamp,
+        _log_id
+    FROM
+        collected_base b
+        LEFT JOIN nf_token_id_base
+        ON b.tx_hash = nf_token_id_base.tx_hash
+        AND b.event_index = nf_token_id_base.event_index_join
+        LEFT JOIN pool_data
+        ON b.contract_address = pool_data.pool_address
+),
+uni_pools AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
+    FROM
+        {{ ref('uniswapv3__ez_pools') }}
+),
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                silver_positions
+        )
+{% if is_incremental() %}
+AND HOUR >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
 )
-
+{% endif %}
+)
 SELECT
-    'ethereum' AS blockchain,
-    b.block_number AS block_number,
-    b.block_timestamp AS block_timestamp,
-    b.tx_hash AS tx_hash,
-    b.event_index AS event_index,
-    b.contract_address AS pool_address,
-    b.origin_from_address AS liquidity_provider,
+    blockchain,
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    A.pool_address,
+    pool_name,
+    liquidity_provider,
     nf_token_id,
-    CASE
-        WHEN nf_token_id IS NULL THEN vault_address
-        ELSE nf_position_manager_address
-    END AS nf_position_manager_address,
-    token0_address,
-    token1_address,
-    b.amount0,
-    b.amount1,
-    b.tick_lower,
-    b.tick_upper,
-    _inserted_timestamp,
-    _log_id
+    nf_position_manager_address,
+    token0_symbol,
+    token1_symbol,
+    amount0 / pow(
+        10,
+        token0_decimals
+    ) AS amount0_adjusted,
+    amount1 / pow(
+        10,
+        token1_decimals
+    ) AS amount1_adjusted,
+    ROUND(
+        amount0_adjusted * p0.price,
+        2
+    ) AS amount0_usd,
+    ROUND(
+        amount1_adjusted * p1.price,
+        2
+    ) AS amount1_usd,
+    tick_lower,
+    tick_upper,
+    pow(
+        1.0001,
+        tick_lower
+    ) / pow(10,(token1_decimals - token0_decimals)) AS price_lower,
+    pow(
+        1.0001,
+        tick_upper
+    ) / pow(10,(token1_decimals - token0_decimals)) AS price_upper,
+    ROUND(
+        price_lower * p1.price,
+        2
+    ) AS price_lower_usd,
+    ROUND(
+        price_upper * p1.price,
+        2
+    ) AS price_upper_usd
 FROM
-    collected_base b
-    LEFT JOIN nf_token_id_base
-    ON b.tx_hash = nf_token_id_base.tx_hash
-    AND b.event_index = nf_token_id_base.event_index_join
-    LEFT JOIN pool_data
-    ON b.contract_address = pool_data.pool_address
+    silver_positions A
+    LEFT JOIN uni_pools p
+    ON A.pool_address = p.pool_address
+    LEFT JOIN token_prices p0
+    ON p0.token_address = A.token0_address
+    AND p0.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )
+    LEFT JOIN token_prices p1
+    ON p1.token_address = A.token1_address
+    AND p1.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )

--- a/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
@@ -143,6 +143,7 @@ token_prices AS (
             FROM
                 silver_positions
         )
+
 {% if is_incremental() %}
 AND HOUR >= (
     SELECT

--- a/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_position_collected_fees.sql
@@ -25,7 +25,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -143,15 +143,6 @@ token_prices AS (
             FROM
                 silver_positions
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
-    FROM
-        {{ this }}
-)
-{% endif %}
 )
 SELECT
     blockchain,

--- a/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
@@ -153,10 +153,124 @@ FINAL AS (
         AND A.nf_token_id :: STRING = b.nf_token_id :: STRING
         LEFT JOIN pool_data C
         ON A.pool_address = C.pool_address
+),
+silver_positions AS (
+    SELECT
+        *
+    FROM
+        FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
+    ORDER BY
+        _inserted_timestamp DESC)) = 1
+),
+uni_pools AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
+    FROM
+        {{ ref('uniswapv3__ez_pools') }}
+),
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                silver_positions
+        )
+
+{% if is_incremental() %}
+AND HOUR >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}
 )
 SELECT
-    *
+    blockchain,
+    block_number,
+    block_timestamp,
+    tx_hash,
+    A.fee_percent,
+    fee_growth_inside0_last_x128,
+    fee_growth_inside1_last_x128,
+    is_active,
+    COALESCE(
+        liquidity / pow(10, (token1_decimals + token0_decimals) / 2),
+        0
+    ) AS liquidity_adjusted,
+    liquidity_provider,
+    nf_position_manager_address,
+    nf_token_id,
+    A.pool_address,
+    pool_name,
+    A.tick_upper,
+    A.tick_lower,
+    pow(1.0001, (tick_lower)) / pow(10,(token1_decimals - token0_decimals)) AS price_lower_1_0,
+    pow(1.0001, (tick_upper)) / pow(10,(token1_decimals - token0_decimals)) AS price_upper_1_0,
+    pow(1.0001, -1 * (tick_upper)) / pow(10,(token0_decimals - token1_decimals)) AS price_lower_0_1,
+    pow(1.0001, -1 * (tick_lower)) / pow(10,(token0_decimals - token1_decimals)) AS price_upper_0_1,
+    price_lower_1_0 * p1.price AS price_lower_1_0_usd,
+    price_upper_1_0 * p1.price AS price_upper_1_0_usd,
+    price_lower_0_1 * p0.price AS price_lower_0_1_usd,
+    price_upper_0_1 * p0.price AS price_upper_0_1_usd,
+    COALESCE(
+        tokensOwed0 / pow(
+            10,
+            token0_decimals
+        ),
+        0
+    ) AS tokens_owed0_adjusted,
+    COALESCE(
+        tokensOwed1 / pow(
+            10,
+            token1_decimals
+        ),
+        0
+    ) AS tokens_owed1_adjusted,
+    COALESCE(
+        tokens_owed0_adjusted * p0.price,
+        0
+    ) AS tokens_owed0_usd,
+    COALESCE(
+        tokens_owed1_adjusted * p1.price,
+        0
+    ) AS tokens_owed1_usd,
+    A.token0_address,
+    A.token1_address,
+    token0_symbol,
+    token1_symbol,
+    _log_id,
+    _inserted_timestamp
 FROM
-    FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
-ORDER BY
-    _inserted_timestamp DESC)) = 1
+    silver_positions A
+    LEFT JOIN uni_pools p
+    ON A.pool_address = p.pool_address
+    LEFT JOIN token_prices p0
+    ON p0.token_address = A.token0_address
+    AND p0.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )
+    LEFT JOIN token_prices p1
+    ON p1.token_address = A.token1_address
+    AND p1.hour = DATE_TRUNC(
+        'hour',
+        block_timestamp
+    )

--- a/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
@@ -96,8 +96,14 @@ pool_data AS (
     SELECT
         token0_address,
         token1_address,
+        fee_percent,
         tick_spacing,
-        pool_address
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
     FROM
         {{ ref('silver__univ3_pools') }}
 ),
@@ -161,22 +167,6 @@ silver_positions AS (
         FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
     ORDER BY
         _inserted_timestamp DESC)) = 1
-),
-uni_pools AS (
-    SELECT
-        token0_address,
-        token1_address,
-        fee,
-        fee_percent,
-        tick_spacing,
-        pool_address,
-        token0_symbol,
-        token1_symbol,
-        token0_decimals,
-        token1_decimals,
-        pool_name
-    FROM
-        {{ ref('uniswapv3__ez_pools') }}
 ),
 token_prices AS (
     SELECT
@@ -260,7 +250,7 @@ SELECT
     _inserted_timestamp
 FROM
     silver_positions A
-    LEFT JOIN uni_pools p
+    LEFT JOIN pool_data p
     ON A.pool_address = p.pool_address
     LEFT JOIN token_prices p0
     ON p0.token_address = A.token0_address

--- a/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_positions.sql
@@ -32,7 +32,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -86,7 +86,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )
@@ -182,15 +182,6 @@ token_prices AS (
             FROM
                 silver_positions
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
-    FROM
-        {{ this }}
-)
-{% endif %}
 )
 SELECT
     blockchain,

--- a/models/silver/protocols/uniswapv3/silver__univ3_positions.yml
+++ b/models/silver/protocols/uniswapv3/silver__univ3_positions.yml
@@ -26,6 +26,13 @@ models:
         tests:
           - not_null:
               enabled: True
+      - name: LIQUIDITY_ADJUSTED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
       - name: FEE_GROWTH_INSIDE1_LAST_x128
         tests:
           - not_null:
@@ -37,6 +44,12 @@ models:
         tests:
           - not_null
       - name: NF_POSITION_MANAGER_ADDRESS
+        tests:
+          - not_null
+      - name: TOKENS_OWED0_USD
+        tests:
+          - not_null
+      - name: TOKENS_OWED1_USD
         tests:
           - not_null
       - name: NF_TOKEN_ID

--- a/models/silver/protocols/uniswapv3/silver__univ3_swaps.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_swaps.sql
@@ -62,8 +62,7 @@ pool_data AS (
     FROM
         {{ ref('silver__univ3_pools') }}
 ),
-
-FINAL AS (
+silver_swaps AS (
     SELECT
         'ethereum' AS blockchain,
         block_number,
@@ -90,6 +89,127 @@ FINAL AS (
         base_swaps
         INNER JOIN pool_data
         ON pool_data.pool_address = base_swaps.contract_address
+),
+uni_pools AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address,
+        token0_symbol,
+        token1_symbol,
+        token0_decimals,
+        token1_decimals,
+        pool_name
+    FROM
+        {{ ref('uniswapv3__ez_pools') }}
+),
+token_prices AS (
+    SELECT
+        HOUR,
+        LOWER(token_address) AS token_address,
+        price
+    FROM
+        {{ ref('price__ez_hourly_token_prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                silver_swaps
+        )
+        AND (
+            token_address IN (
+                SELECT
+                    DISTINCT(token0_address)
+                FROM
+                    uni_pools
+            )
+            OR token_address IN (
+                SELECT
+                    DISTINCT(token1_address)
+                FROM
+                    uni_pools
+            )
+        )
+),
+FINAL AS (
+    SELECT
+        s.blockchain,
+        s.block_number,
+        s.block_timestamp,
+        s.tx_hash,
+        s.pool_address,
+        p.pool_name,
+        recipient,
+        sender,
+        tick,
+        s.fee,
+        liquidity,
+        amount0_unadj,
+        amount1_unadj,
+        COALESCE(
+            liquidity / pow(10,((token0_decimals + token1_decimals) / 2)),
+            0
+        ) AS liquidity_adjusted,
+        event_index,
+        amount0_unadj / pow(
+            10,
+            COALESCE(
+                token0_decimals,
+                18
+            )
+        ) AS amount0_adjusted,
+        amount1_unadj / pow(
+            10,
+            COALESCE(
+                token1_decimals,
+                18
+            )
+        ) AS amount1_adjusted,
+        COALESCE(div0(ABS(amount1_adjusted), ABS(amount0_adjusted)), 0) AS price_1_0,
+        COALESCE(div0(ABS(amount0_adjusted), ABS(amount1_adjusted)), 0) AS price_0_1,
+        p0.price AS token0_price,
+        p1.price AS token1_price,
+        CASE
+            WHEN token0_decimals IS NOT NULL THEN ROUND(
+                token0_price * amount0_adjusted,
+                2
+            )
+        END AS amount0_usd,
+        CASE
+            WHEN token1_decimals IS NOT NULL THEN ROUND(
+                token1_price * amount1_adjusted,
+                2
+            )
+        END AS amount1_usd,
+        s.token0_address,
+        s.token1_address,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        token0_symbol,
+        token1_symbol,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        silver_swaps s
+        LEFT JOIN uni_pools p
+        ON s.pool_address = p.pool_address
+        LEFT JOIN token_prices p0
+        ON p0.token_address = s.token0_address
+        AND p0.hour = DATE_TRUNC(
+            'hour',
+            block_timestamp
+        )
+        LEFT JOIN token_prices p1
+        ON p1.token_address = s.token1_address
+        AND p1.hour = DATE_TRUNC(
+            'hour',
+            block_timestamp
+        )
 )
 SELECT
     *

--- a/models/silver/protocols/uniswapv3/silver__univ3_swaps.sql
+++ b/models/silver/protocols/uniswapv3/silver__univ3_swaps.sql
@@ -45,7 +45,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '36 hours'
     FROM
         {{ this }}
 )


### PR DESCRIPTION
- Moved gold view price joins and transformations into silver incremental tables
- Will require a FR on silver and gold level uni v3 models:
    - `dbt run -m models/silver/protocols/uniswapv3 models/gold/protocols/uniswapv3 --full-refresh -t dev-2xl`
    - `ez_pool_stats` > 300M rows so will run with DBT emergency
- Silver table updates are backward compatible with downstream streamline read models so won't need to FR there
    - All models successful with `dbt run -m models/silver/protocols/uniswapv3+` except `ethereum_share` models--But I am seeing the same issues on main branch so it does not have to do with this PR specifically
- Query time for Univ3 is cut down by ~85-95%