### PR TITLE
fix/duped-abi-qualify

### DIFF
--- a/models/silver/abis/v2/silver__complete_event_abis2.sql
+++ b/models/silver/abis/v2/silver__complete_event_abis2.sql
@@ -9,6 +9,7 @@ WITH proxies AS (
 
     SELECT
         created_block,
+        proxy_created_block,
         contract_address,
         proxy_address,
         start_block,
@@ -63,7 +64,9 @@ base AS (
         inputs,
         event_type,
         ea._inserted_timestamp,
+        pb._inserted_timestamp AS proxy_inserted_timestamp,
         pb.start_block,
+        pb.proxy_created_block,
         pb.contract_address AS base_contract_address,
         1 AS priority
     FROM
@@ -81,7 +84,9 @@ base AS (
         inputs,
         event_type,
         eab._inserted_timestamp,
+        pbb._inserted_timestamp AS proxy_inserted_timestamp,
         pbb.created_block AS start_block,
+        pbb.proxy_created_block,
         pbb.contract_address AS base_contract_address,
         2 AS priority
     FROM
@@ -89,7 +94,9 @@ base AS (
         JOIN (
             SELECT
                 DISTINCT contract_address,
-                created_block
+                created_block,
+                proxy_created_block,
+                _inserted_timestamp
             FROM
                 proxies
         ) pbb
@@ -105,7 +112,9 @@ base AS (
         inputs,
         event_type,
         _inserted_timestamp,
+        NULL AS proxy_inserted_timestamp,
         0 AS start_block,
+        NULL AS proxy_created_block,
         contract_address AS base_contract_address,
         3 AS priority
     FROM
@@ -124,20 +133,26 @@ new_records AS (
         event_name,
         abi,
         start_block,
+        proxy_created_block,
         simple_event_name,
         event_signature,
         NAME,
         inputs,
         event_type,
-        _inserted_timestamp
+        _inserted_timestamp,
+        proxy_inserted_timestamp
     FROM
         base qualify ROW_NUMBER() over (
             PARTITION BY parent_contract_address,
             NAME,
             event_type,
+            event_signature,
             start_block
             ORDER BY
-                priority ASC
+                priority ASC,
+                _inserted_timestamp DESC,
+                proxy_created_block DESC NULLS LAST,
+                proxy_inserted_timestamp DESC NULLS LAST
         ) = 1
 )
 SELECT
@@ -145,12 +160,14 @@ SELECT
     event_name,
     abi,
     start_block,
+    proxy_created_block,
     simple_event_name,
     event_signature,
     IFNULL(LEAD(start_block) over (PARTITION BY parent_contract_address, event_signature
 ORDER BY
     start_block) -1, 1e18) AS end_block,
     _inserted_timestamp,
+    proxy_inserted_timestamp,
     SYSDATE() AS _updated_timestamp
 FROM
     new_records qualify ROW_NUMBER() over (

--- a/models/silver/abis/v2/silver__proxies2.sql
+++ b/models/silver/abis/v2/silver__proxies2.sql
@@ -93,8 +93,11 @@ SELECT
     f.start_block,
     f._id,
     f._inserted_timestamp,
-    C.block_number AS created_block
+    C.block_number AS created_block,
+    p.block_number AS proxy_created_block
 FROM
     FINAL f
     JOIN {{ ref('silver__created_contracts') }} C
     ON f.contract_address = C.created_contract_address
+    JOIN {{ ref('silver__created_contracts') }} p
+    ON f.proxy_address = p.created_contract_address


### PR DESCRIPTION
1. Adds proxy_created_block to proxies2
2. Qualifies on add'tl columns to resolve conflicts with dupes / output consistency
3. Requires FR on proxies2 and complete_event_abis2