### PR TITLE
AN-4156/missing-index

### DIFF
--- a/models/beacon_chain/gold/beacon_chain__fact_attestations.sql
+++ b/models/beacon_chain/gold/beacon_chain__fact_attestations.sql
@@ -8,6 +8,7 @@ SELECT
     slot_number,
     slot_timestamp,
     epoch_number,
+    attestation_slot,
     attestation_index,
     aggregation_bits,
     beacon_block_root,

--- a/models/beacon_chain/gold/beacon_chain__fact_attestations.yml
+++ b/models/beacon_chain/gold/beacon_chain__fact_attestations.yml
@@ -10,6 +10,8 @@ models:
         description: '{{ doc("eth_slot_timestamp") }}'
       - name: EPOCH_NUMBER
         description: '{{ doc("eth_epoch_number") }}'
+      - name: ATTESTATION_SLOT
+        description: 'The slot number in which the validator is attesting on'
       - name: ATTESTATION_INDEX
         description: 'A number that identifies which committee the validator belongs to in a given slot'
       - name: AGGREGARION_BITS

--- a/models/beacon_chain/silver/silver__beacon_attestations.sql
+++ b/models/beacon_chain/silver/silver__beacon_attestations.sql
@@ -10,6 +10,7 @@ SELECT
     slot_number,
     slot_timestamp,
     epoch_number,
+    VALUE :data :slot :: INTEGER AS attestation_slot,
     VALUE :data :index :: INTEGER AS attestation_index,
     VALUE :aggregation_bits :: STRING AS aggregation_bits,
     VALUE :data :beacon_block_root :: STRING AS beacon_block_root,
@@ -20,14 +21,14 @@ SELECT
     VALUE :signature :: STRING AS attestation_signature,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-        ['slot_number', 'attestation_index', 'aggregation_bits', 'beacon_block_root', 'attestation_signature']
+        ['slot_number', 'attestation_slot', 'attestation_index', 'aggregation_bits', 'beacon_block_root', 'attestation_signature']
     ) }} AS id
 FROM
     {{ ref('silver__beacon_blocks') }},
     LATERAL FLATTEN(
         input => attestations
     )
-WHERE epoch_number IS NOT NULL
+WHERE attestations IS NOT NULL
 
 {% if is_incremental() %}
 AND

--- a/models/beacon_chain/silver/silver__beacon_attestations.yml
+++ b/models/beacon_chain/silver/silver__beacon_attestations.yml
@@ -32,6 +32,13 @@ models:
               column_type_list:
                 - NUMBER
                 - FLOAT
+      - name: ATTESTATION_SLOT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
       - name: ATTESTATION_INDEX
         tests:
           - not_null

--- a/models/beacon_chain/silver/silver__beacon_blocks.sql
+++ b/models/beacon_chain/silver/silver__beacon_blocks.sql
@@ -6,20 +6,17 @@
     on_schema_change = 'append_new_columns',
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(slot_number)",
     incremental_predicates = ["dynamic_range", "slot_number"],
-    full_refresh = false,
     tags = ['beacon']
 ) }}
+--    full_refresh = false,
 
 SELECT
     slot_number,
-    DATA :message :body :attestations [0] :data :target :epoch :: INTEGER AS epoch_number,
-    -- status
+    FLOOR(slot_number / 32) AS epoch_number,
     TO_TIMESTAMP(
         DATA :message :body :execution_payload :timestamp :: INTEGER
     ) AS slot_timestamp,
     DATA :message :proposer_index :: INTEGER AS proposer_index,
-    -- will need to link to other source for validator via the index above
-    -- blockRoot Hash
     DATA :message :parent_root :: STRING AS parent_root,
     DATA :message :state_root :: STRING AS state_root,
     DATA :message :body :randao_reveal :: STRING AS randao_reveal,

--- a/models/beacon_chain/silver/silver__beacon_blocks.yml
+++ b/models/beacon_chain/silver/silver__beacon_blocks.yml
@@ -17,7 +17,7 @@ models:
       - name: SLOT_TIMESTAMP
         tests:
           - not_null:
-              where: SLOT_NUMBER >= 4700013 AND EPOCH_NUMBER IS NOT NULL
+              where: SLOT_NUMBER >= 4700013 AND EXECUTION_PAYLOAD IS NOT NULL
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
@@ -33,64 +33,48 @@ models:
                 - FLOAT
       - name: PROPOSER_INDEX
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
                 - FLOAT
       - name: PARENT_ROOT
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
                 - VARCHAR
       - name: STATE_ROOT
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
                 - VARCHAR
       - name: RANDAO_REVEAL
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
                 - VARCHAR
       - name: GRAFFITI
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
                 - VARCHAR
       - name: ETH1_BLOCK_HASH
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
                 - VARCHAR
       - name: ETH1_DEPOSIT_COUNT
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
                 - FLOAT
       - name: ETH1_DEPOSIT_ROOT
         tests:
-          - not_null:
-              where: EPOCH_NUMBER IS NOT NULL
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING

--- a/models/beacon_chain/silver/silver__beacon_deposits.sql
+++ b/models/beacon_chain/silver/silver__beacon_deposits.sql
@@ -25,7 +25,7 @@ FROM
         input => deposits
     )
 WHERE
-    epoch_number IS NOT NULL
+    deposits IS NOT NULL
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/beacon_chain/silver/silver__beacon_withdrawals.sql
+++ b/models/beacon_chain/silver/silver__beacon_withdrawals.sql
@@ -23,8 +23,8 @@ FROM
         input => withdrawals
     )
 WHERE
-    epoch_number IS NOT NULL
-    AND slot_number > 6209119 -- adjust this to the slot number of the first withdrawal
+    withdrawals IS NOT NULL
+    AND slot_number > 6209119 -- slot number of the first withdrawal
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/streamline/bronze/beacon/bronze__beacon_blocks.sql
+++ b/models/streamline/bronze/beacon/bronze__beacon_blocks.sql
@@ -51,6 +51,6 @@ WITH meta AS (
                 '-32009',
                 '-32010'
             )
-            OR DATA NOT ILIKE '%not found%'
-            OR DATA NOT ILIKE '%internal server error%'
         )
+        AND DATA NOT ILIKE '%not found%'
+        AND DATA NOT ILIKE '%internal server error%'

--- a/models/streamline/bronze/beacon/bronze__beacon_validators.sql
+++ b/models/streamline/bronze/beacon/bronze__beacon_validators.sql
@@ -52,6 +52,6 @@ WITH meta AS (
                 '-32009',
                 '-32010'
             )
-            OR DATA NOT ILIKE '%not found%'
-            OR DATA NOT ILIKE '%internal server error%'
         )
+        AND DATA NOT ILIKE '%not found%'
+        AND DATA NOT ILIKE '%internal server error%'

--- a/models/streamline/bronze/beacon/bronze__fr_beacon_blocks.sql
+++ b/models/streamline/bronze/beacon/bronze__fr_beacon_blocks.sql
@@ -51,6 +51,6 @@ WHERE
             '-32009',
             '-32010'
         )
-        OR DATA NOT ILIKE '%not found%'
-        OR DATA NOT ILIKE '%internal server error%'
     )
+    AND DATA NOT ILIKE '%not found%'
+    AND DATA NOT ILIKE '%internal server error%'

--- a/models/streamline/bronze/beacon/bronze__fr_beacon_validators.sql
+++ b/models/streamline/bronze/beacon/bronze__fr_beacon_validators.sql
@@ -52,6 +52,6 @@ WHERE
             '-32009',
             '-32010'
         )
-        OR DATA NOT ILIKE '%not found%'
-        OR DATA NOT ILIKE '%internal server error%'
     )
+    AND DATA NOT ILIKE '%not found%'
+    AND DATA NOT ILIKE '%internal server error%'


### PR DESCRIPTION
1. Added calc for `epoch_number` and modified downstream models accordingly to properly capture BC activity and missing withdrawal index
2. Added `attestation_slot` column
3. Modified where clause in bronze to properly filter values
4. Requires FR on beacon models for updated epoch values and new column
5. Requires FR on complete models + history/realtime jobs to reload failed blocks (confirmed accurate in node)