### PR TITLE
AN-4282/stakewise-v3-lsd

### DIFF
--- a/models/silver/defi/liquid_staking/silver_lsd__complete_lsd_deposits.sql
+++ b/models/silver/defi/liquid_staking/silver_lsd__complete_lsd_deposits.sql
@@ -581,6 +581,42 @@ WHERE
   )
 {% endif %}
 ),
+stakewise_v3 AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    event_name,
+    contract_address,
+    sender,
+    recipient,
+    eth_amount,
+    eth_amount_adj,
+    token_amount,
+    token_amount_adj,
+    token_address,
+    token_symbol,
+    platform,
+    'v3' AS version,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_lsd__stakewise_v3_deposits') }}
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
 swell AS (
   SELECT
     block_number,
@@ -729,6 +765,11 @@ all_lsd_standard AS (
     *
   FROM
     stakewise
+  UNION ALL
+  SELECT
+    *
+  FROM
+    stakewise_v3
   UNION ALL
   SELECT
     *

--- a/models/silver/defi/liquid_staking/silver_lsd__complete_lsd_withdrawals.sql
+++ b/models/silver/defi/liquid_staking/silver_lsd__complete_lsd_withdrawals.sql
@@ -403,6 +403,42 @@ WHERE
   )
 {% endif %}
 ),
+stakewise_v3 AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    event_name,
+    contract_address,
+    sender,
+    recipient,
+    eth_amount,
+    eth_amount_adj,
+    token_amount,
+    token_amount_adj,
+    token_address,
+    token_symbol,
+    platform,
+    'v3' AS version,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_lsd__stakewise_v3_withdrawals') }}
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
 unieth AS (
   SELECT
     block_number,
@@ -480,6 +516,11 @@ all_lsd_standard AS (
     *
   FROM
     sharedstake_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    stakewise_v3
   UNION ALL
   SELECT
     *

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.sql
@@ -1,0 +1,84 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH vaults AS (
+
+    SELECT 
+        vault_address
+    FROM
+        {{ ref('silver_lsd__stakewise_v3_vaults') }}
+),
+
+deposits AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        tx_hash,
+        event_index,
+        'Deposited' AS event_name,
+        contract_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS caller,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS receiver,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            )
+        ) AS eth_amount,
+        (eth_amount / pow(10, 18)) :: FLOAT AS eth_amount_adj,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS token_amount,
+        (token_amount / pow(10, 18)) :: FLOAT AS token_amount_adj,
+        CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 25, 40)) AS referrer,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }} l 
+    INNER JOIN vaults v ON l.contract_address = v.vault_address
+    WHERE
+        topics [0] :: STRING = '0x861a4138e41fb21c121a7dbb1053df465c837fc77380cc7226189a662281be2c' --Deposited/Stake
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    event_name,
+    contract_address,
+    caller AS sender,
+    receiver AS recipient,
+    eth_amount,
+    eth_amount_adj,
+    token_amount,
+    token_amount_adj,
+    '0xf1c9acdc66974dfb6decb12aa385b9cd01190e38' AS token_address,
+    'osETH' AS token_symbol,
+    'stakewise-v3' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    deposits

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.sql
@@ -51,7 +51,7 @@ deposits AS (
         topics [0] :: STRING = '0x861a4138e41fb21c121a7dbb1053df465c837fc77380cc7226189a662281be2c' --Deposited/Stake
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+AND l._inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.yml
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_deposits.yml
@@ -1,0 +1,60 @@
+version: 2
+models:
+  - name: silver_lsd__stakewise_v3_deposits
+    description: osETH - value accruing token (token value relative to ETH increases)
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: ORIGIN_FUNCTION_SIGNATURE
+      - name: ORIGIN_FROM_ADDRESS
+      - name: ORIGIN_TO_ADDRESS
+      - name: TX_HASH
+        tests:
+          - not_null
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: CONTRACT_ADDRESS
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: '^0x[0-9a-fA-F]+$'
+      - name: RECIPIENT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: '^0x[0-9a-fA-F]+$'
+      - name: ETH_AMOUNT
+        tests:
+          - not_null
+      - name: ETH_AMOUNT_ADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_AMOUNT
+        tests:
+          - not_null
+      - name: TOKEN_AMOUNT_ADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.sql
@@ -58,7 +58,7 @@ vaults AS (
         topics [0] :: STRING = '0x0d606510f33b5e566ed1ca2b9e88d388ab81cea532909665d725b33134516aff' --VaultCreated
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+AND l._inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.sql
@@ -1,0 +1,88 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    tags = ['curated']
+) }}
+
+WITH factories AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        from_address AS deployer_address,
+        to_address AS factory_address,
+        _call_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        from_address = '0x229f53ef905545aa53a721d82dbfe4ced7aff65d' --StakeWise: Deployer 1
+        AND TYPE ILIKE 'create%'
+        AND tx_status ILIKE 'success'
+        AND trace_status ILIKE 'success'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+
+qualify(ROW_NUMBER() over(PARTITION BY to_address
+ORDER BY
+    _inserted_timestamp DESC)) = 1
+),
+vaults AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        l.event_index,
+        l.contract_address,
+        deployer_address,
+        factory_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS admin,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS vault,
+        _log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+        l
+        INNER JOIN factories f
+        ON l.contract_address = f.factory_address
+    WHERE
+        topics [0] :: STRING = '0x0d606510f33b5e566ed1ca2b9e88d388ab81cea532909665d725b33134516aff' --VaultCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+AND vault NOT IN (
+    SELECT
+        DISTINCT vault_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    event_index,
+    deployer_address,
+    factory_address,
+    admin AS admin_address,
+    vault AS vault_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    vaults

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.yml
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_vaults.yml
@@ -1,0 +1,7 @@
+version: 2
+models:
+  - name: silver_lsd__stakewise_v3_vaults
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - VAULT_ADDRESS

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.sql
@@ -53,7 +53,7 @@ withdrawals AS (
         topics [0] :: STRING = '0xeb3b05c070c24f667611fdb3ff75fe007d42401c573aed8d8faca95fd00ccb56' --ExitedAssetsClaimed/Unstake
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+AND l._inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.sql
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.sql
@@ -1,0 +1,86 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH vaults AS (
+
+    SELECT 
+        vault_address
+    FROM
+        {{ ref('silver_lsd__stakewise_v3_vaults') }}
+),
+
+withdrawals AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        tx_hash,
+        event_index,
+        'ExitedAssetsClaimed' AS event_name,
+        contract_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS receiver,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            )
+        ) AS eth_amount,
+        (eth_amount / pow(10, 18)) :: FLOAT AS eth_amount_adj,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            )
+        ) AS prevPositionTicket,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS newPositionTicket,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }} l 
+    INNER JOIN vaults v ON l.contract_address = v.vault_address
+    WHERE
+        topics [0] :: STRING = '0xeb3b05c070c24f667611fdb3ff75fe007d42401c573aed8d8faca95fd00ccb56' --ExitedAssetsClaimed/Unstake
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    event_name,
+    contract_address,
+    origin_from_address AS sender,
+    receiver AS recipient,
+    eth_amount,
+    eth_amount_adj,
+    eth_amount AS token_amount,
+    eth_amount_adj AS token_amount_adj,
+    '0xf1c9acdc66974dfb6decb12aa385b9cd01190e38' AS token_address,
+    'osETH' AS token_symbol,
+    'stakewise-v3' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    withdrawals

--- a/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.yml
+++ b/models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_v3_withdrawals.yml
@@ -1,0 +1,60 @@
+version: 2
+models:
+  - name: silver_lsd__stakewise_v3_withdrawals
+    description: osETH - value accruing token (token value relative to ETH increases)
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: ORIGIN_FUNCTION_SIGNATURE
+      - name: ORIGIN_FROM_ADDRESS
+      - name: ORIGIN_TO_ADDRESS
+      - name: TX_HASH
+        tests:
+          - not_null
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: CONTRACT_ADDRESS
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: '^0x[0-9a-fA-F]+$'
+      - name: RECIPIENT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: '^0x[0-9a-fA-F]+$'
+      - name: ETH_AMOUNT
+        tests:
+          - not_null
+      - name: ETH_AMOUNT_ADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_AMOUNT
+        tests:
+          - not_null
+      - name: TOKEN_AMOUNT_ADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null


### PR DESCRIPTION
1. Adds new silver tables for stakewise-v3, including vaults, deposits and withdrawals

Requires `dbt run -m models/silver/defi/liquid_staking/stakewise+ --full-refresh --exclude models/silver/defi/liquid_staking/stakewise/silver_lsd__stakewise_deposits.sql`