### PR TITLE
AN-3883/new-crv-pools

### DIFF
--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -39,13 +39,13 @@ WHERE
     AND TYPE ilike 'create%'
     AND TX_STATUS ilike 'success'
 {% if is_incremental() %}
-{# AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '12 hours'
-    FROM
-        {{ this }}
-) #}
---revert after run
+-- AND _inserted_timestamp >= (
+    -- SELECT
+        -- MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    -- FROM
+        -- {{ this }}
+-- )
+-- revert after run
 AND contract_address NOT IN ( 
     SELECT
         pool_address

--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -33,14 +33,22 @@ WHERE
         '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
         '0x3e0139ce3533a42a7d342841aee69ab2bfee1d51',
         '0xbabe61887f1de2713c6f97e567623453d3c79f67',
-        '0x7f7abe23fc1ad4884b726229ceaafb1179e9c9cf'
+        '0x7f7abe23fc1ad4884b726229ceaafb1179e9c9cf',
+        '0x4f8846ae9380b90d2e71d5e3d042dff3e7ebb40d'
     )
     AND TYPE ilike 'create%'
     AND TX_STATUS ilike 'success'
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+{# AND _inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+) #}
+--revert after run
+AND contract_address NOT IN ( 
+    SELECT
+        pool_address
     FROM
         {{ this }}
 )


### PR DESCRIPTION
1. New deployer contract to pull in new pools, including 28 with crvUSD as requested by user
2. Includes temp logic to incrementally read new pools only (requires follow up PR to revert this logic)

```dbt run -m models/silver/defi/dex/curve/silver_dex__curve_pools.sql && dbt run -m models/silver/defi/dex/curve/silver_dex__curve_swaps.sql models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql models/silver/defi/dex/silver_dex__complete_dex_swaps.sql --full-refresh```