### PR TITLE
AN-4336/update-hashflow-v3-swaps-to-include-router-swaps

### DIFF
--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -44,7 +44,7 @@ SELECT
     block_number,
     block_timestamp,
     deployer_address,
-    C.name,
+    C.name as pool_name,
     contract_address AS pool_address,
     _call_id,
     d._inserted_timestamp

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -39,13 +39,16 @@ qualify(ROW_NUMBER() over(PARTITION BY to_address
 ORDER BY
     block_timestamp ASC)) = 1
 )
-
 SELECT
     tx_hash,
     block_number,
     block_timestamp,
     deployer_address,
+    C.name,
     contract_address AS pool_address,
     _call_id,
-    _inserted_timestamp
-FROM contract_deployments 
+    d._inserted_timestamp
+FROM
+    contract_deployments d
+    LEFT JOIN {{ ref('silver__contracts') }} C
+    ON pool_address = address

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -9,7 +9,8 @@
 WITH pools AS (
 
     SELECT
-        pool_address
+        pool_address,
+        pool_name
     FROM
         {{ ref('silver_dex__hashflow_pools') }}
 ),
@@ -23,6 +24,7 @@ router_swaps_base AS (
         origin_to_address,
         l.event_index,
         l.contract_address,
+        p.pool_name,
         regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
         CONCAT(
             '0x',
@@ -87,6 +89,7 @@ swaps_base AS (
         origin_to_address,
         l.event_index,
         l.contract_address,
+        pool_name,
         regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
         CONCAT(
             '0x',
@@ -151,6 +154,7 @@ FINAL AS (
         origin_to_address,
         event_index,
         contract_address,
+        pool_name,
         origin_from_address AS sender,
         account_address AS tx_to,
         tokenIn AS token_in,
@@ -173,6 +177,7 @@ FINAL AS (
         origin_to_address,
         event_index,
         contract_address,
+        pool_name,
         origin_from_address AS sender,
         account_address AS tx_to,
         tokenIn AS token_in,
@@ -195,6 +200,7 @@ SELECT
     origin_to_address,
     event_index,
     contract_address,
+    pool_name,
     sender,
     tx_to,
     CASE

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_pools.sql
@@ -5,23 +5,24 @@
     tags = ['curated']
 ) }}
 
-WITH contract_deployments AS (
-
+WITH logs_pull as (
     SELECT
         tx_hash,
         block_number,
         block_timestamp,
-        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        origin_from_address AS deployer_address,
-        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        data,
+        contract_address,
+        origin_from_address,
         _log_id,
         _inserted_timestamp
     FROM
         {{ ref('silver__logs') }}
     WHERE
-        contract_address = '0xde828fdc3f497f16416d1bb645261c7c6a62dab5'
-        AND topics [0] :: STRING = '0xdbd2a1ea6808362e6adbec4db4969cbc11e3b0b28fb6c74cb342defaaf1daada'
-
+        (
+            contract_address = '0xde828fdc3f497f16416d1bb645261c7c6a62dab5'
+            AND topics [0] :: STRING = '0xdbd2a1ea6808362e6adbec4db4969cbc11e3b0b28fb6c74cb342defaaf1daada'
+        )
+        OR tx_hash = '0x89ded8a7efaec848cc4230e160dbfdb262008d43276b75d0647d2f96938aefb1'
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -30,12 +31,48 @@ AND _inserted_timestamp >= (
         {{ this }}
 )
 {% endif %}
+),
+contract_deployments AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        origin_from_address AS deployer_address,
+        c.name as pool_name,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+         logs_pull l 
+    LEFT JOIN
+        {{ ref('silver__contracts') }} C
+    ON
+        pool_address = address
+    WHERE
+        contract_address = '0xde828fdc3f497f16416d1bb645261c7c6a62dab5'
+
 )
 SELECT
     tx_hash,
     block_number,
     block_timestamp,
+    origin_from_address as deployer_address,
+    'router' as pool_name,
+    contract_address as pool_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    logs_pull
+WHERE tx_hash = '0x89ded8a7efaec848cc4230e160dbfdb262008d43276b75d0647d2f96938aefb1'
+UNION ALL
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
     deployer_address,
+    pool_name,
     pool_address,
     _log_id,
     _inserted_timestamp

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
@@ -92,8 +92,12 @@ router_swaps AS (
             )
             ELSE LOWER(CONCAT('0x', SUBSTR(decoded_flat :quoteToken, 27)))
         END AS tokenOut,
-        decoded_flat :baseTokenAmount AS amountIn,
-        decoded_flat :quoteTokenAmount AS amountOut,
+        TRY_TO_NUMBER(
+            decoded_flat :baseTokenAmount :: STRING
+         ) AS amountIn,
+        TRY_TO_NUMBER(
+            decoded_flat :quoteTokenAmount :: STRING
+        ) AS amountOut,
         l._log_id,
         l._inserted_timestamp
     FROM

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
@@ -62,6 +62,63 @@ AND _inserted_timestamp >= (
         {{ this }}
 )
 {% endif %}
+),
+router_swaps AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        l.origin_function_signature,
+        l.origin_from_address,
+        l.origin_to_address,
+        CASE
+            WHEN l.topics [0] = '0x3f72b2a38919490277652bb34955c871b20e23068c243319c9fa5e27963d9e12' THEN 'Trade'
+            WHEN l.topics [0] = '0x34f57786fb01682fb4eec88d340387ef01a168fe345ea5b76f709d4e560c10eb' THEN 'XChainTrade'
+        ELSE NULL END AS event_name,
+        l.event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 25, 40)) AS effective_trader_address,
+        --The trader wallet address that will swap with the contract. This can be a proxy contract
+        NULL AS trader_address, 
+        --The wallet address of the actual trader
+        CONCAT(
+            '0x',
+            segmented_data [2] :: STRING
+        ) AS txid,
+        CONCAT('0x', SUBSTR(segmented_data [5] :: STRING, 25, 40)) AS tokenIn,
+        CONCAT('0x', SUBSTR(segmented_data [6] :: STRING, 25, 40)) AS tokenOut,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [7] :: STRING
+            )
+        ) AS amountIn,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [8] :: STRING
+            )
+        ) AS amountOut,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_logs') }}
+        l
+    WHERE
+        l.topics [0] :: STRING IN (
+            '0x3f72b2a38919490277652bb34955c871b20e23068c243319c9fa5e27963d9e12' --Xchaintrade
+            ,'0x34f57786fb01682fb4eec88d340387ef01a168fe345ea5b76f709d4e560c10eb' --Router trade
+        )
+    AND
+        origin_to_address = lower('0x55084eE0fEf03f14a305cd24286359A35D735151') --router
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
 )
 SELECT
     block_number,
@@ -91,3 +148,32 @@ SELECT
     _inserted_timestamp
 FROM
     swaps
+UNION ALL
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    effective_trader_address AS sender,
+    trader_address AS tx_to,
+    txid,
+    CASE
+        WHEN tokenIn = '0x0000000000000000000000000000000000000000' THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        ELSE tokenIn
+    END AS token_in,
+    CASE
+        WHEN tokenOut = '0x0000000000000000000000000000000000000000' THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        ELSE tokenOut
+    END AS token_out,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    event_name,
+    'hashflow-v3' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    router_swaps

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
@@ -71,45 +71,27 @@ router_swaps AS (
         l.origin_function_signature,
         l.origin_from_address,
         l.origin_to_address,
-        CASE
-            WHEN l.topics [0] = '0x3f72b2a38919490277652bb34955c871b20e23068c243319c9fa5e27963d9e12' THEN 'Trade'
-            WHEN l.topics [0] = '0x34f57786fb01682fb4eec88d340387ef01a168fe345ea5b76f709d4e560c10eb' THEN 'XChainTrade'
-        ELSE NULL END AS event_name,
+        'XChainTrade'AS event_name,
         l.event_index,
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 25, 40)) AS effective_trader_address,
+        decoded_flat :effectiveTrader AS effective_trader_address,
         --The trader wallet address that will swap with the contract. This can be a proxy contract
-        NULL AS trader_address, 
+        NULL AS trader_address,
         --The wallet address of the actual trader
-        CONCAT(
-            '0x',
-            segmented_data [2] :: STRING
-        ) AS txid,
-        CONCAT('0x', SUBSTR(segmented_data [5] :: STRING, 25, 40)) AS tokenIn,
-        CONCAT('0x', SUBSTR(segmented_data [6] :: STRING, 25, 40)) AS tokenOut,
-        TRY_TO_NUMBER(
-            utils.udf_hex_to_int(
-                segmented_data [7] :: STRING
-            )
-        ) AS amountIn,
-        TRY_TO_NUMBER(
-            utils.udf_hex_to_int(
-                segmented_data [8] :: STRING
-            )
-        ) AS amountOut,
+        decoded_flat :txid AS txid,
+        decoded_flat :baseToken AS tokenIn,
+        decoded_flat :quoteToken AS tokenOut,
+        decoded_flat :baseTokenAmount AS amountIn,
+        decoded_flat :quoteTokenAmount AS amountOut,
         l._log_id,
         l._inserted_timestamp
     FROM
         {{ ref('silver__decoded_logs') }}
         l
     WHERE
-        l.topics [0] :: STRING IN (
-            '0x3f72b2a38919490277652bb34955c871b20e23068c243319c9fa5e27963d9e12' --Xchaintrade
-            ,'0x34f57786fb01682fb4eec88d340387ef01a168fe345ea5b76f709d4e560c10eb' --Router trade
-        )
-    AND
-        origin_to_address = lower('0x55084eE0fEf03f14a305cd24286359A35D735151') --router
+        l.topics [0] :: STRING = '0x3f72b2a38919490277652bb34955c871b20e23068c243319c9fa5e27963d9e12' --Xchaintrade
+        AND origin_to_address = LOWER('0x55084eE0fEf03f14a305cd24286359A35D735151') --router
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.yml
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.yml
@@ -48,6 +48,7 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+              where: EVENT_NAME <> 'XChainTrade'
       - name: PLATFORM
         tests:
           - dbt_expectations.expect_column_values_to_be_in_type_list:

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.yml
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.yml
@@ -39,14 +39,10 @@ models:
       - name: TOKEN_OUT
         tests:
           - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
       - name: SENDER
         tests:
           - not_null:
               where: BLOCK_TIMESTAMP > '2021-08-01'
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
       - name: TX_TO
         tests:
           - not_null

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -634,29 +634,32 @@ hashflow_swaps AS (
     'v1' AS version,
     token_in,
     token_out,
-    CONCAT(
-      LEAST(
-        COALESCE(
-          symbol_in,
-          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+    CASE
+      WHEN pool_name IS NULL THEN CONCAT(
+        LEAST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
         ),
-        COALESCE(
-          symbol_out,
-          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
-        )
-      ),
-      '-',
-      GREATEST(
-        COALESCE(
-          symbol_in,
-          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
-        ),
-        COALESCE(
-          symbol_out,
-          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        '-',
+        GREATEST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
         )
       )
-    ) AS pool_name,
+      ELSE pool_name
+    END AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
@@ -708,29 +711,32 @@ hashflow_v3_swaps AS (
     'v3' AS version,
     token_in,
     token_out,
-    CONCAT(
-      LEAST(
-        COALESCE(
-          symbol_in,
-          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+    CASE
+      WHEN pool_name IS NULL THEN CONCAT(
+        LEAST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
         ),
-        COALESCE(
-          symbol_out,
-          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
-        )
-      ),
-      '-',
-      GREATEST(
-        COALESCE(
-          symbol_in,
-          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
-        ),
-        COALESCE(
-          symbol_out,
-          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        '-',
+        GREATEST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
         )
       )
-    ) AS pool_name,
+      ELSE pool_name
+    END AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.yml
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.yml
@@ -75,7 +75,7 @@ models:
               where: PLATFORM NOT IN ('uniswap-v3','curve')
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
-              where: PLATFORM <> 'hashflow-v3'
+              where: EVENT_NAME <> 'XChainTrade'
       - name: SYMBOL_IN
         tests:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
@@ -99,7 +99,7 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
-              where: PLATFORM <> 'hashflow-v3'
+              where: EVENT_NAME <> 'XChainTrade'
               enabled: False
       - name: PLATFORM
         tests:

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.yml
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.yml
@@ -75,6 +75,7 @@ models:
               where: PLATFORM NOT IN ('uniswap-v3','curve')
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+              where: PLATFORM <> 'hashflow-v3'
       - name: SYMBOL_IN
         tests:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
@@ -98,6 +99,7 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+              where: PLATFORM <> 'hashflow-v3'
               enabled: False
       - name: PLATFORM
         tests:


### PR DESCRIPTION
- Adds router to pools
- Adds XChainSwap events
   - Exclude XChainSwaps from address tests
   - Only a few of these, not on all chains. 100 on ARB, 27 ETH and 1 on AVAX and Poly
   - Decodes Solana addresses via new base_58 decoder
- Adds pool names to v1 and v3