### PR TITLE
traces history

### DIFF
--- a/.github/workflows/dbt_run_streamline_traces_decoder_history_range_test.yml
+++ b/.github/workflows/dbt_run_streamline_traces_decoder_history_range_test.yml
@@ -1,0 +1,45 @@
+name: dbt_run_streamline_traces_decoder_history_range_test
+run-name: dbt_run_streamline_traces_decoder_history_range_test
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs “At minute 30 past every 12th hour.” (see https://crontab.guru)
+    - cron: '30 */12 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod_backfill
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":480,"row_limit":20000000}' -m "ethereum_models,tag:streamline_decoded_traces_history_range_test" "ethereum_models,tag:streamline_decoded_traces_complete"

--- a/.github/workflows/dbt_run_streamline_traces_decoder_history_range_test.yml
+++ b/.github/workflows/dbt_run_streamline_traces_decoder_history_range_test.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_streamline_traces_decoder_history_range_test
 on:
   workflow_dispatch:
   schedule:
-    # Runs “At minute 30 past every 12th hour.” (see https://crontab.guru)
-    - cron: '30 */12 * * *'
+    # Runs “At minute 41 past every 12th hour.” (see https://crontab.guru)
+    - cron: '41 */12 * * *'
     
 env:
   DBT_PROFILES_DIR: ./

--- a/macros/streamline/models.sql
+++ b/macros/streamline/models.sql
@@ -62,6 +62,77 @@ WHERE
     )
 {% endmacro %}
 
+{% macro decode_traces_history(
+        start,
+        stop
+    ) %}
+
+WITH look_back AS (
+
+    SELECT
+        block_number
+    FROM
+        {{ ref("_max_block_by_date") }}
+        qualify ROW_NUMBER() over (
+            ORDER BY
+                block_number DESC
+        ) = 1
+)
+SELECT
+    t.block_number,
+    t.tx_hash,
+    t.trace_index,
+    _call_id,
+    A.abi AS abi,
+    A.function_name AS function_name,
+    CASE
+        WHEN TYPE = 'DELEGATECALL' THEN from_address
+        ELSE to_address
+    END AS abi_address,
+    t.input AS input,
+    COALESCE(
+        t.output,
+        '0x'
+    ) AS output
+FROM
+    {{ ref("silver__traces") }}
+    t
+    INNER JOIN {{ ref("silver__complete_function_abis") }} A
+    ON A.parent_contract_address = abi_address
+    AND LEFT(
+        t.input,
+        10
+    ) = LEFT(
+        A.function_signature,
+        10
+    )
+    AND t.block_number BETWEEN A.start_block
+    AND A.end_block
+WHERE
+    (t.block_number BETWEEN {{ start }} AND {{ stop }})
+    and t.block_number < (
+        SELECT
+            block_number
+        FROM
+            look_back
+    )
+    AND t.block_number IS NOT NULL
+    AND _call_id NOT IN (
+        SELECT
+            _call_id
+        FROM
+            {{ ref("streamline__complete_decode_traces") }}
+        WHERE
+            (block_number BETWEEN {{ start }} AND {{ stop }})
+            and block_number < (
+                SELECT
+                    block_number
+                FROM
+                    look_back
+            ))
+
+{% endmacro %}
+
 {% macro streamline_external_table_query(
         model,
         partition_function,

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018908895_018943246.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018908895_018943246.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018943247_018981366.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018943247_018981366.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018981367_019017880.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_018981367_019017880.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019017881_019050916.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019017881_019050916.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019050917_019083530.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019050917_019083530.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019083531_019116985.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019083531_019116985.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019116986_019148786.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019116986_019148786.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019148787_019182777.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019148787_019182777.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019182778_019220379.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019182778_019220379.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019220380_019255380.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019220380_019255380.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019255381_019290381.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019255381_019290381.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019290382_019325382.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019290382_019325382.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019325383_019360383.sql
+++ b/models/streamline/silver/decoder/history/traces/range_test/streamline__decode_traces_history_019325383_019360383.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    tags = ['streamline_decoded_traces_history_range_test']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_traces_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
- traces history models from Jan 1 2024 onwards
- `dbt run -m models/streamline/silver/decoder/history/traces/range_test --full-refresh`