### PR TITLE
op-bedrock-decoded-logs-to-logs-fix

### DIFF
--- a/models/silver/optimism/silver__optimism_bedrock_state_hashes.sql
+++ b/models/silver/optimism/silver__optimism_bedrock_state_hashes.sql
@@ -12,13 +12,20 @@ WITH base AS (
         tx_hash,
         block_number,
         block_timestamp,
-        decoded_flat: outputRoot :: STRING AS output_root,
-        decoded_flat: l2OutputIndex :: INT AS batch_index,
-        decoded_flat: l2BlockNumber :: INT AS min_l2_block_number,
-        decoded_flat: l1Timestamp :: TIMESTAMP AS l1_timestamp,
+        contract_address,
+        topics [1] :: STRING AS output_root,
+        utils.udf_hex_to_int(
+            topics [2] :: STRING
+        ) :: INT AS batch_index,
+        utils.udf_hex_to_int(
+            topics [3] :: STRING
+        ) :: INT AS min_l2_block_number,
+        utils.udf_hex_to_int(
+            DATA :: STRING
+        ) :: TIMESTAMP AS l1_timestamp,
         _inserted_timestamp
     FROM
-        {{ ref('silver__decoded_logs') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0xa7aaf2512769da4e444e3de247be2564225c2e7a8f74cfe528e46e17d24868e2'
         AND contract_address = '0xdfe97868233d1aa22e815a266982f2cf17685a27'


### PR DESCRIPTION
Full refreshed dev with new model and compared to prod. New model matches exactly to old:

```
    select
        *
    from 
        ethereum_dev.silver.optimism_bedrock_state_hashes D
    INNER JOIN 
        ethereum.silver.optimism_bedrock_state_hashes P
    ON
        D.STATE_TX_HASH = P.STATE_TX_HASH
    WHERE
            (D.state_tx_hash <> P.state_tx_hash)
            or
            (D.state_block_number <> P.state_block_number)
            or
            (D.state_block_timestamp <> P.state_block_timestamp)
            or
            (D.state_batch_index <> P.state_batch_index)
            or
            (D.state_batch_root <> P.state_batch_root)
            or
            (D.state_batch_size <> P.state_batch_size)
            or
            (D.state_prev_total_elements <> P.state_prev_total_elements)
            or
            (D.state_min_block <> P.state_min_block)
            or
            (D.state_max_block <> P.state_max_block)
```