### PR TITLE
Fix blend new loans logic 

### DIFF
--- a/models/silver/nft/lending/blur/silver_nft__blend_new_loans.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_new_loans.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "_log_id",
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['curated','reorg']
 ) }}
@@ -15,10 +15,54 @@ WITH raw_logs AS (
         event_index,
         event_name,
         decoded_flat,
+        decoded_flat :lienId :: STRING AS lienid,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_logs') }}
+    WHERE
+        block_timestamp :: DATE >= '2023-05-01'
+        AND contract_address = '0x29469395eaf6f95920e59f858042f0e28d98a20b'
+        AND event_name IN (
+            'LoanOfferTaken',
+            'Refinance'
+        )
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+filtered_loan_events AS (
+    SELECT
+        tx_hash,
+        lienid,
+        COUNT(1) AS new_loan_filter
+    FROM
+        raw_logs
+    GROUP BY
+        tx_hash,
+        lienid
+    HAVING
+        new_loan_filter = 1
+),
+base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        event_name,
+        decoded_flat,
         decoded_flat :auctionDuration AS auction_duration_blocks,
         decoded_flat :borrower :: STRING AS borrower_address,
         decoded_flat :lender :: STRING AS lender_address,
-        decoded_flat :lienId :: STRING AS lienid,
+        lienid,
         decoded_flat :collection :: STRING AS nft_address,
         decoded_flat :tokenId :: STRING AS tokenId,
         decoded_flat :loanAmount :: INT AS loan_amount,
@@ -32,53 +76,53 @@ WITH raw_logs AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__decoded_logs') }}
+        raw_logs
     WHERE
-        block_timestamp :: DATE >= '2023-05-01'
-        AND contract_address = '0x29469395eaf6f95920e59f858042f0e28d98a20b'
-        AND event_name IN (
-            'LoanOfferTaken'
+        lienid IN (
+            SELECT
+                lienid
+            FROM
+                filtered_loan_events
         )
-        AND tx_status = 'SUCCESS'
+),
+FINAL AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        event_name,
+        decoded_flat,
+        auction_duration_blocks,
+        borrower_address,
+        lender_address,
+        lienid,
+        nft_address,
+        tokenId,
+        loan_amount,
+        interest_rate_bps,
+        interest_rate,
+        offerhash,
+        event_type,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        base
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
-    FROM
-        {{ this }}
-)
-AND lienid NOT IN (
-    SELECT
-        lienid
-    FROM
-        {{ this }}
-)
+UNION ALL
+SELECT
+    *
+FROM
+    {{ this }}
 {% endif %}
 )
 SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    event_index,
-    event_name,
-    decoded_flat,
-    auction_duration_blocks,
-    borrower_address,
-    lender_address,
-    lienid,
-    nft_address,
-    tokenId,
-    loan_amount,
-    interest_rate_bps,
-    interest_rate,
-    offerhash,
-    event_type,
-    _log_id,
-    _inserted_timestamp
+    *
 FROM
-    raw_logs qualify ROW_NUMBER() over (
+    FINAL qualify ROW_NUMBER() over (
         PARTITION BY lienid
         ORDER BY
-            block_timestamp ASC
+            block_timestamp ASC,
+            event_index ASC
     ) = 1

--- a/models/silver/nft/lending/blur/silver_nft__blend_new_loans.yml
+++ b/models/silver/nft/lending/blur/silver_nft__blend_new_loans.yml
@@ -4,7 +4,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - _LOG_ID
+            - LIENID
     columns:
       - name: BLOCK_NUMBER
         tests:


### PR DESCRIPTION
Change logic to ensure only new loan transactions go through - for cases when a refinance transaction lands in the table earlier than a new loan transaction 

`dbt run -m models/silver/nft/lending/blur/silver_nft__blend_new_loans.sql models/silver/nft/lending/blur/silver_nft__blend_loans.sql models/silver/nft/lending/blur/silver_nft__blend_repayments.sql --full-refresh && dbt run -m models/silver/nft/lending/complete_lending/silver_nft__complete_loans.sql --vars '{"HEAL_CURATED_MODEL":["blend"]}' && dbt run -m models/silver/nft/lending/complete_lending/silver_nft__complete_repayments.sql --var '{"HEAL_CURATED_MODEL":["blend"]}'`