### PR TITLE
add art blocks, add decimals logic in complete nft

### DIFF
--- a/models/doc_descriptions/nft/nft_event_type.md
+++ b/models/doc_descriptions/nft/nft_event_type.md
@@ -1,5 +1,5 @@
 {% docs nft_event_type %}
 
-The type of NFT event in this transaction, either `sale`,  `bid_won` or `redeem`. 
+The type of NFT event in this transaction, either `sale`,  `bid_won`, `redeem` or `mint` .
 
 {% enddocs %}

--- a/models/gold/nft/nft__ez_nft_sales.yml
+++ b/models/gold/nft/nft__ez_nft_sales.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: nft__ez_nft_sales
-    description: This table contains NFT sale events from Opensea (Wyvern & Seaport), Blur, Rarible, X2Y2, Looksrare, NFTx, Sudoswap, and Larvalabs (Cryptopunks)
+    description: This table contains NFT sale events from Opensea (Wyvern & Seaport), Blur, Rarible, X2Y2, Looksrare, NFTx, Sudoswap, Larvalabs (Cryptopunks) and Art Blocks
 
     columns:
       - name: BLOCK_NUMBER

--- a/models/silver/nft/lending/complete_lending/silver_nft__complete_liquidations.sql
+++ b/models/silver/nft/lending/complete_lending/silver_nft__complete_liquidations.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "block_number",
+    unique_key = ['block_number', 'platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
     tags = ['curated','reorg']
 ) }}

--- a/models/silver/nft/lending/complete_lending/silver_nft__complete_loans.sql
+++ b/models/silver/nft/lending/complete_lending/silver_nft__complete_loans.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "block_number",
+    unique_key = ['block_number', 'platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
     tags = ['curated','reorg']
 ) }}

--- a/models/silver/nft/lending/complete_lending/silver_nft__complete_repayments.sql
+++ b/models/silver/nft/lending/complete_lending/silver_nft__complete_repayments.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "block_number",
+    unique_key = ['block_number', 'platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
     tags = ['curated','reorg']
 ) }}

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.sql
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.sql
@@ -1,0 +1,417 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+/*
+Old artblocks contracts 
+0x059edd72cd353df5106d2b9cc5ab83a52287ac3a
+0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270
+
+Current artblocks
+0x99a9b7c1116f9ceeb1652de04d5969cce509b069
+
+Artblocks collaborations
+0x145789247973c5d612bf121e9e4eef84b63eb707
+0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36
+0x64780ce53f6e966e18a22af13a2f97369580ec11
+
+Artblocks explorations
+0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a
+*/
+WITH all_address AS (
+
+    SELECT
+        block_timestamp,
+        created_contract_address AS address
+    FROM
+        {{ ref('silver__created_contracts') }}
+    WHERE
+        block_timestamp :: DATE >= '2020-01-01'
+        AND creator_address IN (
+            '0x6f8af4f14826405c5a361860de9f26acdaeab49b',
+            -- old snowfro,
+            '0xf3860788d1597cecf938424baabe976fac87dc26',
+            -- snowfro,
+            '0x96dc73c8b5969608c77375f085949744b5177660',
+            -- deployer 1,
+            '0xb8559af91377e5bab052a4e9a5088cb65a9a4d63' -- deployer 2
+        )
+),
+function_sig_list AS (
+    SELECT
+        function_name,
+        LEFT(
+            function_signature,
+            10
+        ) AS function_sig,
+        COUNT(1) AS txs
+    FROM
+        {{ ref('silver__flat_function_abis') }}
+    WHERE
+        (
+            function_name LIKE 'purchase%'
+            OR function_name LIKE 'purchaseTo%'
+        )
+        AND contract_address IN (
+            SELECT
+                address
+            FROM
+                all_address
+        )
+    GROUP BY
+        ALL
+),
+raw_traces AS (
+    SELECT
+        *,
+        LEFT(
+            input,
+            10
+        ) AS function_sig,
+        regexp_substr_all(SUBSTR(input, 11, len(input)), '.{64}') AS segmented_input,
+        regexp_substr_all(SUBSTR(output, 3, len(output)), '.{64}') AS segmented_output
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        block_timestamp :: DATE >= '2020-11-01'
+        AND to_address IN (
+            SELECT
+                address
+            FROM
+                all_address
+        )
+        AND trace_status = 'SUCCESS'
+        AND (
+            function_sig IN (
+                SELECT
+                    function_sig
+                FROM
+                    function_sig_list
+            )
+            OR function_sig IN (
+                '0x498dd0c1',
+                -- currency addresss
+                '0x8639415b' -- get primary revenue split
+            )
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+purchase_function AS (
+    -- to get mints via Minter / Settlement - in ETH
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_position,
+        tx_hash,
+        trace_index,
+        from_address,
+        to_address,
+        eth_value,
+        eth_value_precise,
+        function_sig,
+        segmented_input,
+        to_address AS purchase_contract,
+        IFF (
+            function_sig IN (
+                SELECT
+                    function_sig
+                FROM
+                    function_sig_list
+                WHERE
+                    function_name LIKE 'purchaseTo%'
+            ),
+            utils.udf_hex_to_int(
+                segmented_input [1] :: STRING
+            ),
+            utils.udf_hex_to_int(
+                segmented_input [0] :: STRING
+            )
+        ) :: INT AS project_id,
+        utils.udf_hex_to_int(SUBSTR(output, 3, 64)) :: STRING AS tokenid,
+        ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            project_id
+            ORDER BY
+                trace_index ASC
+        ) AS intra_tx_grouping
+    FROM
+        raw_traces
+    WHERE
+        function_sig IN (
+            SELECT
+                function_sig
+            FROM
+                function_sig_list
+        )
+),
+collaboration_purchase AS (
+    -- collaboration nfts in ETH only
+    SELECT
+        tx_hash,
+        utils.udf_hex_to_int(
+            segmented_input [0] :: STRING
+        ) :: INT AS project_id,
+        utils.udf_hex_to_int(
+            segmented_input [1] :: STRING
+        ) :: INT AS revenue_split_price_raw,
+        utils.udf_hex_to_int(
+            segmented_output [0] :: STRING
+        ) :: INT AS revenue_split_platform_raw,
+        ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            project_id
+            ORDER BY
+                trace_index ASC
+        ) AS intra_tx_grouping
+    FROM
+        raw_traces
+    WHERE
+        to_address IN (
+            '0x145789247973c5d612bf121e9e4eef84b63eb707',
+            '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+            '0x64780ce53f6e966e18a22af13a2f97369580ec11'
+        )
+        AND function_sig = '0x8639415b'
+),
+token_currency AS (
+    SELECT
+        tx_hash,
+        '0x' || SUBSTR(
+            segmented_output [0] :: STRING,
+            25
+        ) AS token_contract_address
+    FROM
+        raw_traces
+    WHERE
+        function_sig = '0x498dd0c1' qualify ROW_NUMBER() over (
+            PARTITION BY tx_hash
+            ORDER BY
+                trace_index ASC
+        ) = 1
+),
+pre_settlement_nft_mints AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address AS nft_address,
+        (utils.udf_hex_to_int(topics [3] :: STRING)) :: INT AS project_id,
+        (utils.udf_hex_to_int(topics [2] :: STRING)) :: STRING AS tokenid,
+        '0x' || SUBSTR(
+            topics [2] :: STRING,
+            25
+        ) AS nft_to_address_logs,
+        ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            nft_address
+            ORDER BY
+                event_index ASC
+        ) AS row_num,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        block_timestamp :: DATE >= '2020-11-01'
+        AND contract_address IN (
+            SELECT
+                address
+            FROM
+                all_address
+            WHERE
+                block_timestamp :: DATE < '2022-10-11'
+        )
+        AND topics [0] :: STRING IN (
+            '0x94c792774c59479f7bd68442f3af3691c02123a5aabee8b6f9116d8af8aa6669',
+            '0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f'
+        )
+),
+post_settlement_nft_mints AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address AS nft_address,
+        tokenid,
+        to_address AS nft_to_address_logs,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__nft_transfers') }}
+    WHERE
+        block_timestamp :: DATE >= '2022-10-11'
+        AND contract_address IN (
+            SELECT
+                address
+            FROM
+                all_address
+            WHERE
+                block_timestamp :: DATE >= '2022-10-11'
+        )
+        AND from_address = '0x0000000000000000000000000000000000000000'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+all_nft_mints AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        nft_address,
+        project_id,
+        tokenid,
+        nft_to_address_logs,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        pre_settlement_nft_mints
+    UNION ALL
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        nft_address,
+        NULL AS project_id,
+        tokenid,
+        nft_to_address_logs,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        post_settlement_nft_mints
+),
+final_mint_base AS (
+    SELECT
+        m.block_number,
+        m.block_timestamp,
+        tx_position,
+        m.tx_hash,
+        IFF(
+            p.tx_hash IS NULL,
+            'external_mint',
+            'regular'
+        ) AS mint_type,
+        event_index,
+        trace_index,
+        from_address,
+        to_address,
+        COALESCE(
+            eth_value,
+            0
+        ) AS mint_eth_value,
+        function_sig,
+        segmented_input,
+        purchase_contract,
+        nft_address,
+        COALESCE(
+            m.project_id,
+            p.project_id
+        ) AS project_id,
+        m.tokenid,
+        nft_to_address_logs,
+        intra_tx_grouping,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        all_nft_mints m
+        LEFT JOIN purchase_function p USING (
+            tx_hash,
+            tokenid
+        )
+    WHERE
+        nft_address IN (
+            '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270',
+            '0x99a9b7c1116f9ceeb1652de04d5969cce509b069',
+            '0x059edd72cd353df5106d2b9cc5ab83a52287ac3a',
+            '0x145789247973c5d612bf121e9e4eef84b63eb707',
+            '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+            '0x64780ce53f6e966e18a22af13a2f97369580ec11',
+            '0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a'
+        )
+),
+token_transfers AS (
+    SELECT
+        tx_hash,
+        from_address,
+        to_address,
+        event_index,
+        contract_address,
+        raw_amount
+    FROM
+        {{ ref('silver__transfers') }}
+    WHERE
+        block_timestamp :: DATE >= '2020-11-01'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    b.block_number,
+    b.block_timestamp,
+    tx_position,
+    b.tx_hash,
+    intra_tx_grouping,
+    mint_type,
+    b.event_index,
+    trace_index,
+    b.from_address,
+    b.to_address,
+    mint_eth_value,
+    revenue_split_price_raw,
+    revenue_split_platform_raw,
+    function_sig,
+    segmented_input,
+    purchase_contract,
+    nft_address,
+    project_id,
+    tokenid,
+    nft_to_address_logs,
+    t.tx_hash AS transfers_hash,
+    t.from_address AS transfers_from_address,
+    t.to_address AS transfers_to_address,
+    t.event_index AS transfers_event_index,
+    t.contract_address AS transfers_contract_address,
+    t.raw_amount AS transfers_raw_amount,
+    C.token_contract_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    final_mint_base b
+    LEFT JOIN collaboration_purchase USING (
+        tx_hash,
+        project_id,
+        intra_tx_grouping
+    )
+    LEFT JOIN token_transfers t
+    ON b.tx_hash = t.tx_hash
+    AND b.from_address = t.from_address
+    LEFT JOIN token_currency C
+    ON C.tx_hash = b.tx_hash
+    AND C.token_contract_address = t.contract_address

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.yml
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: silver_nft__artblocks_base_sales
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 7
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: NFT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PROJECT_ID
+        tests:
+          - not_null
+      - name: TOKENID
+        tests:
+          - not_null

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.sql
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.sql
@@ -1,0 +1,297 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH seller_base AS (
+
+    SELECT
+        b.block_number,
+        b.block_timestamp,
+        tx_hash,
+        intra_tx_grouping,
+        tx_position,
+        b.event_index,
+        b.from_address,
+        nft_to_address_logs,
+        COALESCE(
+            b.from_address,
+            nft_to_address_logs
+        ) AS buyer_address,
+        COALESCE(
+            b.to_address,
+            nft_address
+        ) AS platform_address,
+        function_sig,
+        purchase_contract,
+        mint_eth_value * pow(
+            10,
+            18
+        ) AS mint_eth_raw,
+        revenue_split_price_raw,
+        revenue_split_platform_raw,
+        nft_address,
+        project_id,
+        tokenid,
+        artist_address,
+        transfers_hash,
+        transfers_from_address,
+        transfers_to_address,
+        transfers_event_index,
+        transfers_contract_address,
+        token_contract_address,
+        transfers_raw_amount,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver_nft__artblocks_base_sales') }}
+        b
+        INNER JOIN {{ ref('silver_nft__artblocks_seller_reads') }}
+        s USING (
+            nft_address,
+            project_id
+        )
+
+{% if is_incremental() %}
+WHERE
+    b._inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+token_transfers_count_filter AS (
+    SELECT
+        tx_hash,
+        COUNT(1) AS transfers_count
+    FROM
+        seller_base
+    WHERE
+        mint_eth_raw = 0
+        AND transfers_hash IS NOT NULL
+        AND tx_position IS NOT NULL
+        AND tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                seller_base
+            WHERE
+                artist_address = transfers_to_address
+                OR token_contract_address = transfers_contract_address
+        )
+    GROUP BY
+        tx_hash
+),
+token_sales_raw AS (
+    SELECT
+        *,
+        IFF(
+            transfers_count > 1,
+            'true',
+            'false'
+        ) AS fees_type
+    FROM
+        seller_base
+        INNER JOIN token_transfers_count_filter USING(tx_hash)
+    WHERE
+        mint_eth_raw = 0
+        AND transfers_hash IS NOT NULL
+        AND tx_position IS NOT NULL
+),
+token_sales_agg AS (
+    SELECT
+        tx_hash,
+        fees_type,
+        transfers_from_address,
+        transfers_contract_address,
+        SUM(transfers_raw_amount) AS total_token_transferred
+    FROM
+        token_sales_raw
+    GROUP BY
+        ALL
+),
+token_sales_base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        intra_tx_grouping,
+        event_index,
+        platform_address,
+        artist_address,
+        artist_address AS seller_address,
+        buyer_address,
+        function_sig,
+        purchase_contract,
+        nft_address,
+        project_id,
+        tokenid,
+        A.transfers_contract_address AS currency_address,
+        A.total_token_transferred AS total_price_raw,
+        IFF(
+            fees_type = 'true',
+            A.total_token_transferred / pow(
+                10,
+                1
+            ),
+            0
+        ) AS platform_fee_raw,
+        0 AS creator_fee_raw,
+        platform_fee_raw + creator_fee_raw AS total_fees_raw,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        seller_base b
+        INNER JOIN token_sales_agg A USING (tx_hash)
+    WHERE
+        mint_eth_raw = 0
+        AND transfers_hash IS NOT NULL
+        AND tx_position IS NOT NULL qualify ROW_NUMBER() over (
+            PARTITION BY tx_hash,
+            intra_tx_grouping
+            ORDER BY
+                transfers_event_index ASC
+        ) = 1
+),
+eth_sales_base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        intra_tx_grouping,
+        event_index,
+        platform_address,
+        artist_address,
+        artist_address AS seller_address,
+        buyer_address,
+        function_sig,
+        purchase_contract,
+        nft_address,
+        project_id,
+        tokenid,
+        'ETH' AS currency_address,
+        CASE
+            WHEN nft_address IN (
+                '0x145789247973c5d612bf121e9e4eef84b63eb707',
+                '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+                '0x64780ce53f6e966e18a22af13a2f97369580ec11'
+            ) THEN COALESCE(
+                revenue_split_price_raw,
+                mint_eth_raw
+            )
+            ELSE mint_eth_raw
+        END AS total_price_raw,
+        CASE
+            WHEN nft_address IN (
+                '0x145789247973c5d612bf121e9e4eef84b63eb707',
+                '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+                '0x64780ce53f6e966e18a22af13a2f97369580ec11'
+            ) THEN COALESCE(
+                revenue_split_platform_raw,
+                mint_eth_raw / pow(
+                    10,
+                    1
+                )
+            )
+            ELSE mint_eth_raw / pow(
+                10,
+                1
+            )
+        END AS platform_fee_raw,
+        0 AS creator_fee_raw,
+        platform_fee_raw + creator_fee_raw AS total_fees_raw,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        seller_base
+    WHERE
+        tx_hash NOT IN (
+            SELECT
+                tx_hash
+            FROM
+                token_sales_base
+        )
+),
+final_base AS (
+    SELECT
+        *
+    FROM
+        token_sales_base
+    UNION ALL
+    SELECT
+        *
+    FROM
+        eth_sales_base
+),
+tx_data AS (
+    SELECT
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature,
+        tx_fee,
+        input_data
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        block_timestamp :: DATE >= '2020-11-01'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    intra_tx_grouping,
+    event_index,
+    'mint' AS event_type,
+    platform_address,
+    'art blocks' AS platform_name,
+    'art blocks' AS platform_exchange_version,
+    artist_address,
+    seller_address,
+    buyer_address,
+    function_sig,
+    purchase_contract,
+    nft_address,
+    project_id,
+    tokenid,
+    NULL AS erc1155_value,
+    currency_address,
+    total_price_raw,
+    platform_fee_raw,
+    creator_fee_raw,
+    total_fees_raw,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    tx_fee,
+    input_data,
+    _log_id,
+    CONCAT(
+        nft_address,
+        '-',
+        tokenId,
+        '-',
+        platform_exchange_version,
+        '-',
+        _log_id
+    ) AS nft_log_id,
+    _inserted_timestamp
+FROM
+    final_base
+    INNER JOIN tx_data USING (tx_hash) qualify(ROW_NUMBER() over(PARTITION BY nft_log_id
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.yml
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.yml
@@ -1,0 +1,107 @@
+version: 2
+models:
+  - name: silver_nft__artblocks_sales
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - nft_log_id
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 7
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SELLER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BUYER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: NFT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKENID
+        tests:
+          - not_null
+      - name: TOTAL_PRICE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: TOTAL_FEES_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: PLATFORM_FEE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: CREATOR_FEE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: TX_FEE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: NFT_LOG_ID
+        tests:
+          - not_null 
+      - name: _LOG_ID
+        tests:
+          - not_null 
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: INPUT_DATA
+        tests:
+          - not_null

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_seller_reads.sql
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_seller_reads.sql
@@ -1,0 +1,143 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ["nft_address", "project_id"],
+    cluster_by = ['nft_address'],
+    tags = ['curated','reorg'],
+    full_refresh = false
+) }}
+/*
+Old artblocks contracts 
+0x059edd72cd353df5106d2b9cc5ab83a52287ac3a
+0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270
+
+Current artblocks
+0x99a9b7c1116f9ceeb1652de04d5969cce509b069
+
+Artblocks collaborations
+0x145789247973c5d612bf121e9e4eef84b63eb707
+0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36
+0x64780ce53f6e966e18a22af13a2f97369580ec11
+
+Artblocks explorations
+0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a
+*/
+WITH inputs AS (
+
+    SELECT
+        nft_address,
+        project_id,
+        CONCAT(
+            nft_address,
+            project_id
+        ) AS nft_address_id,
+        block_number
+    FROM
+        {{ ref('silver_nft__artblocks_base_sales') }}
+    WHERE
+        nft_address IN (
+            '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270',
+            '0x99a9b7c1116f9ceeb1652de04d5969cce509b069',
+            '0x059edd72cd353df5106d2b9cc5ab83a52287ac3a',
+            '0x145789247973c5d612bf121e9e4eef84b63eb707',
+            '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+            '0x64780ce53f6e966e18a22af13a2f97369580ec11',
+            '0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a'
+        )
+
+{% if is_incremental() %}
+AND nft_address_id NOT IN (
+    SELECT
+        nft_address_id
+    FROM
+        {{ this }}
+)
+{% endif %}
+
+qualify ROW_NUMBER() over (
+    PARTITION BY nft_address,
+    project_id
+    ORDER BY
+        block_number ASC,
+        event_index ASC
+) = 2
+),
+build_requests AS (
+    SELECT
+        nft_address_id,
+        nft_address,
+        block_number,
+        CASE
+            WHEN nft_address IN (
+                '0x059edd72cd353df5106d2b9cc5ab83a52287ac3a'
+            ) THEN '0x8c2c3622' -- projectTokenInfo
+            WHEN nft_address IN (
+                '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270',
+                '0x99a9b7c1116f9ceeb1652de04d5969cce509b069',
+                '0x145789247973c5d612bf121e9e4eef84b63eb707',
+                '0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36',
+                '0x64780ce53f6e966e18a22af13a2f97369580ec11',
+                '0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a'
+            ) THEN '0xa47d29cb' --projectIdToArtistAddress
+        END AS function_sig,
+        project_id,
+        CONCAT(
+            function_sig,
+            LPAD(
+                REPLACE(LOWER(utils.udf_int_to_hex(project_id)), '0x', ''),
+                64,
+                0)
+            ) AS DATA,
+            utils.udf_json_rpc_call(
+                'eth_call',
+                [{ 'to': nft_address, 'from': null, 'data': data }, block_number]
+            ) AS rpc_request,
+            ROW_NUMBER() over (
+                ORDER BY
+                    nft_address_id ASC
+            ) AS row_num
+            FROM
+                inputs qualify ROW_NUMBER() over (
+                    ORDER BY
+                        nft_address_id ASC
+                ) <= 500
+        ),
+        requests AS ({% for item in range(10) %}
+            (
+        SELECT
+            nft_address_id, nft_address, project_id, row_num, rpc_request, live.udf_api('POST', CONCAT('{service}', '/', '{Authentication}'),{}, rpc_request, 'Vault/prod/ethereum/quicknode/mainnet') AS resp
+        FROM
+            build_requests
+
+{% if is_incremental() %}
+WHERE
+    row_num BETWEEN ({{ item }} * 50 + 1)
+    AND ((({{ item }} + 1) * 50))
+{% else %}
+WHERE
+    row_num BETWEEN ({{ item }} * 50 + 1)
+    AND ((({{ item }} + 1) * 50))
+{% endif %}) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %})
+SELECT
+    nft_address_id,
+    nft_address,
+    project_id,
+    row_num,
+    rpc_request,
+    resp,
+    resp :data :result :: STRING AS response,
+    regexp_substr_all(SUBSTR(response, 3, len(response)), '.{64}') AS segmented_input,
+    '0x' || SUBSTR(
+        segmented_input [0] :: STRING,
+        25
+    ) AS artist_address,
+    SYSDATE() AS _inserted_timestamp
+FROM
+    requests
+WHERE
+    response IS NOT NULL
+    AND artist_address != '0x0000000000000000000000000000000000000000'
+    AND artist_address IS NOT NULL

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_seller_reads.yml
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_seller_reads.yml
@@ -1,0 +1,14 @@
+version: 2
+models:
+  - name: silver_nft__artblocks_seller_reads
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - nft_address_id
+    columns:
+      - name: ARTIST_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+


### PR DESCRIPTION
1. Add artblocks model 
- a base model to get a list of new artblock sales 
- a reads model to get artist addresses for new project ids 
- a final sales model 

2. Add a logic in complete nft sales to join in decimals and symbol using the contracts model as a backup where there are no entries in the price table 

3. Add a new event type called "mint" only for Art blocks. Existing event types are sale, bid_won and redeem. 

4. update unique key in complete models so that vars runs doesn't delete rows

`dbt run -m models/silver/nft/sales/artblocks --full-refresh && dbt run -m models/silver/nft/sales/silver_nft__complete_nft_sales.sql --vars '{"HEAL_CURATED_MODEL":["artblocks"]}'`