### PR TITLE
add obligation receipt to nftfi v2

### DIFF
--- a/models/gold/nft/lending/nft__ez_lending_loans.yml
+++ b/models/gold/nft/lending/nft__ez_lending_loans.yml
@@ -13,7 +13,7 @@ models:
       - name: EVENT_INDEX
         description: '{{ doc("nft_event_index") }}'
       - name: EVENT_TYPE
-        description: There are 2 types of loan creation events. It can either be a new loan or a refinance of an existing loan. 
+        description: There are 2 types of loan creation events. It can either be a new loan or a refinance of an existing loan. Note that for NFTfi, renegotiation events are categorised as refinance events in this table. As for the refinancing feature on NFTfi, old loans are repaid and new loan ids are reissued so these would be new loan entries in this table. 
       - name: PLATFORM_ADDRESS
         description: The contract address of the platform's lending contract 
       - name: PLATFORM_NAME

--- a/models/silver/nft/lending/blur/silver_nft__blend_liquidations.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_liquidations.sql
@@ -41,7 +41,7 @@ WITH raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -151,7 +151,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/blur/silver_nft__blend_loans.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_loans.sql
@@ -23,7 +23,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -57,7 +57,7 @@ loan_offer_taken_details AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '24 hours'
+            MAX(_inserted_timestamp) - INTERVAL '12 hours'
         FROM
             {{ this }}
     )

--- a/models/silver/nft/lending/blur/silver_nft__blend_new_loans.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_new_loans.sql
@@ -32,7 +32,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/blur/silver_nft__blend_repayments.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_repayments.sql
@@ -40,7 +40,7 @@ repay_txs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -113,7 +113,7 @@ traces_raw AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v1/silver_nft__nftfi_v1_liquidations.sql
+++ b/models/silver/nft/lending/nftfi_v1/silver_nft__nftfi_v1_liquidations.sql
@@ -3,7 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['stale']
+    tags = ['curated', 'reorg']
 ) }}
 
 WITH raw_logs AS (
@@ -51,7 +51,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_liquidations.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_liquidations.sql
@@ -57,7 +57,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_loans.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_loans.sql
@@ -28,7 +28,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -138,7 +138,7 @@ base_raw AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '24 hours'
+            MAX(_inserted_timestamp) - INTERVAL '12 hours'
         FROM
             {{ this }}
     )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_new_loans.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_new_loans.sql
@@ -28,7 +28,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -61,7 +61,7 @@ obligation_receipt_transfers AS (
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_new_loans.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_new_loans.sql
@@ -34,6 +34,50 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
+obligation_receipt_transfers AS (
+    SELECT
+        l.block_timestamp AS transfer_timestamp,
+        l.tx_hash,
+        l.event_index AS transfer_event_index,
+        l.from_address,
+        l.to_address,
+        l.to_address AS origin_borrower_address,
+        l.contract_address AS obligation_receipt_address,
+        l.tokenid AS obligation_token_id,
+        o.loanid
+    FROM
+        {{ ref('silver__nft_transfers') }}
+        l
+        INNER JOIN {{ ref('silver_nft__nftfi_v2_obligation_receipts') }}
+        o USING (
+            tokenid
+        )
+    WHERE
+        l.block_timestamp :: DATE >= '2023-11-04'
+        AND l.contract_address = '0xaabd3ebcc6ae1e87150c6184c038b94dc01a7708'
+        AND l.from_address = '0x25ff4b398cd97b5bfbbe68378aae1f23cbe13bba' -- nftfi refinancing contract. Added here to ensure only nftfi refinances are included
+        AND l.to_address != '0x0000000000000000000000000000000000000000'
+
+{% if is_incremental() %}
+AND l._inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+obligation_receipt_transfers_final AS (
+    SELECT
+        *
+    FROM
+        obligation_receipt_transfers qualify ROW_NUMBER() over (
+            PARTITION BY obligation_token_id
+            ORDER BY
+                transfer_event_index DESC,
+                transfer_timestamp DESC
+        ) = 1
+),
 loan_started AS (
     SELECT
         block_number,
@@ -43,7 +87,7 @@ loan_started AS (
         event_name,
         decoded_flat,
         contract_address,
-        decoded_flat :borrower :: STRING AS borrower_address,
+        decoded_flat :borrower :: STRING AS temp_borrower_address,
         decoded_flat :lender :: STRING AS lender_address,
         decoded_flat :loanExtras :referralFeeInBasisPoints AS referral_fee_bps,
         decoded_flat :loanExtras :revenueShareInBasisPoints AS revenue_share_bps,
@@ -82,7 +126,14 @@ SELECT
     event_name,
     decoded_flat,
     contract_address,
-    borrower_address,
+    temp_borrower_address,
+    origin_borrower_address,
+    COALESCE(
+        origin_borrower_address,
+        temp_borrower_address
+    ) AS borrower_address,
+    obligation_receipt_address,
+    obligation_token_id,
     lender_address,
     referral_fee_bps,
     revenue_share_bps,
@@ -104,3 +155,7 @@ SELECT
     _inserted_timestamp
 FROM
     loan_started
+    LEFT JOIN obligation_receipt_transfers_final USING (
+        tx_hash,
+        loanid
+    )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    trace_index,
+    utils.udf_hex_to_int(
+        decoded_data :decoded_input_data :_data :: STRING
+    ) :: STRING AS loanid,
+    decoded_data :decoded_input_data :_to :: STRING AS mint_to_address,
+    to_address AS obligation_receipt_address,
+    decoded_data :decoded_input_data :_tokenId :: STRING AS tokenid,
+    _inserted_timestamp
+FROM
+    {{ ref('silver__decoded_traces') }}
+WHERE
+    block_timestamp :: DATE >= '2023-11-04'
+    AND trace_status = 'SUCCESS'
+    AND tx_status = 'SUCCESS'
+    AND TYPE = 'CALL'
+    AND to_address = '0xaabd3ebcc6ae1e87150c6184c038b94dc01a7708' -- obligation receipt
+    AND decoded_data :function_name :: STRING = 'mint'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.sql
@@ -31,7 +31,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.yml
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_obligation_receipts.yml
@@ -1,10 +1,11 @@
 version: 2
 models:
-  - name: silver_nft__nftfi_v2_liquidations
+  - name: silver_nft__nftfi_v2_obligation_receipts
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - NFT_LENDING_ID
+            - TX_HASH 
+            - TRACE_INDEX
     columns:
       - name: BLOCK_NUMBER
         tests:
@@ -28,44 +29,20 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
-      - name: EVENT_INDEX
+      - name: TRACE_INDEX
         tests:
           - not_null
       - name: LOANID
         tests:
           - not_null
-      - name: LENDER_ADDRESS
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: BORROWER_ADDRESS
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: NFT_ADDRESS
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
       - name: TOKENID
-        tests:
-          - not_null
-      - name: PRINCIPAL_UNADJ 
-        tests:
-          - not_null
-      - name: INTEREST_RATE 
-        tests:
-          - not_null
-      - name: _LOG_ID
         tests:
           - not_null
       - name: _INSERTED_TIMESTAMP
         tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 14
+              interval: 3
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_LTZ

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_repayments.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_repayments.sql
@@ -54,7 +54,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -84,7 +84,7 @@ obligation_receipt_transfers AS (
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_repayments.sql
+++ b/models/silver/nft/lending/nftfi_v2/silver_nft__nftfi_v2_repayments.sql
@@ -22,7 +22,7 @@ WITH raw_logs AS (
         decoded_flat :adminFee :: INT AS platform_fee_unadj,
         decoded_flat :amountPaidToLender :: INT AS amount_paid_to_lender,
         amount_paid_to_lender + platform_fee_unadj AS debt_unadj,
-        decoded_flat :borrower :: STRING AS borrower_address,
+        decoded_flat :borrower :: STRING AS temp_borrower_address,
         decoded_flat :lender :: STRING AS lender_address,
         decoded_flat :loanERC20Denomination :: STRING AS loan_token_address,
         decoded_flat :loanId AS loanId,
@@ -37,10 +37,7 @@ WITH raw_logs AS (
             loanid,
             '-',
             _log_id
-        ) AS nft_lending_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['loanid', 'borrower_address', 'nft_address','tokenId','platform_exchange_version']
-        ) }} AS unique_loan_id
+        ) AS nft_lending_id
     FROM
         {{ ref('silver__decoded_logs') }}
     WHERE
@@ -62,6 +59,80 @@ AND _inserted_timestamp >= (
         {{ this }}
 )
 {% endif %}
+),
+obligation_receipt_transfers AS (
+    SELECT
+        l.block_timestamp AS transfer_timestamp,
+        l.tx_hash,
+        l.event_index AS transfer_event_index,
+        l.from_address AS origin_borrower_address,
+        l.contract_address AS obligation_receipt_address,
+        l.tokenid AS obligation_token_id,
+        o.loanid
+    FROM
+        {{ ref('silver__nft_transfers') }}
+        l
+        INNER JOIN {{ ref('silver_nft__nftfi_v2_obligation_receipts') }}
+        o USING (
+            tokenid
+        )
+    WHERE
+        l.block_timestamp :: DATE >= '2023-11-04'
+        AND l.contract_address = '0xaabd3ebcc6ae1e87150c6184c038b94dc01a7708'
+        AND l.to_address != '0x0000000000000000000000000000000000000000'
+
+{% if is_incremental() %}
+AND l._inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+repayment_obligation AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        event_name,
+        contract_address,
+        platform_name,
+        platform_address,
+        platform_exchange_version,
+        decoded_flat,
+        platform_fee_unadj,
+        amount_paid_to_lender,
+        debt_unadj,
+        temp_borrower_address,
+        origin_borrower_address,
+        obligation_receipt_address,
+        obligation_token_id,
+        COALESCE(
+            origin_borrower_address,
+            temp_borrower_address
+        ) AS borrower_address,
+        lender_address,
+        loan_token_address,
+        loanId,
+        principal_unadj,
+        nft_address,
+        tokenId,
+        revenueShare,
+        revenueSharePartner,
+        _log_id,
+        _inserted_timestamp,
+        nft_lending_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['loanid', 'borrower_address', 'nft_address','tokenId','platform_exchange_version']
+        ) }} AS unique_loan_id
+    FROM
+        raw_logs
+        LEFT JOIN obligation_receipt_transfers USING (
+            tx_hash,
+            loanid
+        )
 ),
 loan_details AS (
     SELECT
@@ -119,12 +190,15 @@ FINAL AS (
         b.loan_tenure,
         b.loan_due_timestamp,
         l.block_timestamp AS loan_paid_timestamp,
+        l.origin_borrower_address,
+        l.obligation_receipt_address,
+        l.obligation_token_id,
         l._log_id,
         l._inserted_timestamp,
         l.nft_lending_id,
         l.unique_loan_id
     FROM
-        raw_logs l
+        repayment_obligation l
         INNER JOIN loan_details b USING (
             loanid,
             nft_address,
@@ -164,6 +238,9 @@ SELECT
     loan_tenure,
     loan_due_timestamp,
     loan_paid_timestamp,
+    origin_borrower_address,
+    obligation_receipt_address,
+    obligation_token_id,
     _log_id,
     _inserted_timestamp,
     nft_lending_id,

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.sql
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_base_sales.sql
@@ -101,7 +101,7 @@ raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -241,7 +241,7 @@ pre_settlement_nft_mints AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -275,7 +275,7 @@ post_settlement_nft_mints AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -375,7 +375,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.sql
+++ b/models/silver/nft/sales/artblocks/silver_nft__artblocks_sales.sql
@@ -59,7 +59,7 @@ WITH seller_base AS (
 WHERE
     b._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '24 hours'
+            MAX(_inserted_timestamp) - INTERVAL '12 hours'
         FROM
             {{ this }}
     )
@@ -244,7 +244,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__blur_blend_sales.sql
+++ b/models/silver/nft/sales/silver_nft__blur_blend_sales.sql
@@ -47,7 +47,7 @@ WITH raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -281,7 +281,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -350,7 +350,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__blur_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__blur_decoded_sales.sql
@@ -53,7 +53,7 @@ WITH base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -112,7 +112,7 @@ buyers_list AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -148,7 +148,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__blur_v2.sql
+++ b/models/silver/nft/sales/silver_nft__blur_v2.sql
@@ -35,7 +35,7 @@ WITH blur_v2_tx AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -104,7 +104,7 @@ blur_v2_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -948,7 +948,7 @@ takeAsk_nft_sale_details_raw AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1208,7 +1208,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__cryptopunk_bids.sql
+++ b/models/silver/nft/sales/silver_nft__cryptopunk_bids.sql
@@ -42,7 +42,7 @@ WITH base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__cryptopunk_sales.sql
+++ b/models/silver/nft/sales/silver_nft__cryptopunk_sales.sql
@@ -60,7 +60,7 @@ WITH raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -87,7 +87,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -247,7 +247,7 @@ nft_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -275,7 +275,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__looksrare_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__looksrare_decoded_sales.sql
@@ -131,7 +131,7 @@ platform_fee_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -208,7 +208,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -242,7 +242,7 @@ nft_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__looksrare_v2.sql
+++ b/models/silver/nft/sales/silver_nft__looksrare_v2.sql
@@ -19,7 +19,7 @@ WITH raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -218,7 +218,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -245,7 +245,7 @@ nft_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__magiceden_sales.sql
+++ b/models/silver/nft/sales/silver_nft__magiceden_sales.sql
@@ -47,7 +47,7 @@ WITH decoded_trace AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -108,7 +108,7 @@ raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -186,7 +186,7 @@ raw_events AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -832,7 +832,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__nftx_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__nftx_decoded_sales.sql
@@ -38,7 +38,7 @@ direct_vault_redeems AS (
 {% if is_incremental() %}
 AND TO_TIMESTAMP_NTZ(_inserted_timestamp) >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -55,7 +55,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -127,7 +127,7 @@ all_swaps AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -513,7 +513,7 @@ swap_nft_for_eth_from_vault_nft_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -543,7 +543,7 @@ swap_nft_for_eth_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -686,7 +686,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND TO_TIMESTAMP_NTZ(_inserted_timestamp) >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -712,7 +712,7 @@ nft_transfers AS (
 {% if is_incremental() %}
 AND TO_TIMESTAMP_NTZ(_inserted_timestamp) >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__nftx_vaults.sql
+++ b/models/silver/nft/sales/silver_nft__nftx_vaults.sql
@@ -21,9 +21,7 @@ WITH vaults AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        )
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__rarible_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__rarible_decoded_sales.sql
@@ -31,7 +31,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -101,7 +101,7 @@ raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -420,7 +420,7 @@ raw_nft_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -445,7 +445,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__rarible_v2_sales.sql
+++ b/models/silver/nft/sales/silver_nft__rarible_v2_sales.sql
@@ -27,7 +27,7 @@ WITH raw AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -950,7 +950,7 @@ payment_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1113,7 +1113,7 @@ logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1143,7 +1143,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__seaport_1_1_sales.sql
+++ b/models/silver/nft/sales/silver_nft__seaport_1_1_sales.sql
@@ -32,7 +32,7 @@ seaport_tx_table AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -73,7 +73,7 @@ decoded AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1048,7 +1048,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1089,7 +1089,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__seaport_1_4_sales.sql
+++ b/models/silver/nft/sales/silver_nft__seaport_1_4_sales.sql
@@ -31,7 +31,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -89,7 +89,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1653,7 +1653,7 @@ mao_orderhash AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1694,7 +1694,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__seaport_1_5_sales.sql
+++ b/models/silver/nft/sales/silver_nft__seaport_1_5_sales.sql
@@ -37,7 +37,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -79,7 +79,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1865,7 +1865,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1906,7 +1906,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__seaport_1_6_sales.sql
+++ b/models/silver/nft/sales/silver_nft__seaport_1_6_sales.sql
@@ -37,7 +37,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -79,7 +79,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1865,7 +1865,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -1906,7 +1906,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__sudoswap_sales.sql
+++ b/models/silver/nft/sales/silver_nft__sudoswap_sales.sql
@@ -23,7 +23,7 @@ WITH sudoswap_tx AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -55,7 +55,7 @@ raw_tx AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -117,7 +117,7 @@ raw_traces AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -218,7 +218,7 @@ sudo_indicator_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__wyvern_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__wyvern_decoded_sales.sql
@@ -818,7 +818,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/sales/silver_nft__x2y2_decoded_sales.sql
+++ b/models/silver/nft/sales/silver_nft__x2y2_decoded_sales.sql
@@ -71,7 +71,7 @@ maker = nft buyer #}
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -143,7 +143,7 @@ nft_details AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -179,7 +179,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )


### PR DESCRIPTION
NFTfi v2 added a contract that allows for users with existing loans to accept other loans. It does this by:
1. taking a flash loan to repay old loan
2. Accepts the money from new loan and use that to repay flash loan 

However because the contract does this for the user, the user first have to mint an obligation receipt and sends this to the contract. This means the contract gains ownership of the loan momentarily, which in turn causes the event logs to show that the borrower is the contract address instead of the user.

Changes in this PR is to ensure the user address remains as the borrower instead of the contract 

`dbt run -m models/silver/nft/lending/nftfi_v2 models/silver/nft/lending/nftfi_v1/silver_nft__nftfi_v1_liquidations.sql --full-refresh && dbt run -m models/silver/nft/lending/complete_lending/silver_nft__complete_loans.sql --vars '{"HEAL_MODELS":["nftfi_v2"]}' && dbt run -m models/silver/nft/lending/complete_lending/silver_nft__complete_repayments.sql --vars '{"HEAL_MODELS":["nftfi_v2"]}' && dbt run -m models/silver/nft/lending/complete_lending/silver_nft__complete_liquidations.sql --vars '{"HEAL_MODELS":["nftfi_v2", "nftfi_v1"]}'`