### PR TITLE
beacon-validators-sl2

### DIFF
--- a/models/streamline/bronze/beacon/bronze__streamline_beacon_validators.sql
+++ b/models/streamline/bronze/beacon/bronze__streamline_beacon_validators.sql
@@ -1,55 +1,8 @@
 {{ config (
     materialized = 'view'
 ) }}
-
-WITH meta AS (
-
-    SELECT
-        last_modified AS _inserted_timestamp,
-        file_name,
-        CAST(
-            SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER
-        ) AS _partition_by_block_id
-    FROM
-        TABLE(
-            information_schema.external_table_file_registration_history(
-                start_time => DATEADD('day', -3, CURRENT_TIMESTAMP()),
-                table_name => '{{ source( "bronze_streamline", "beacon_validators") }}')
-            ) A
-        )
-    SELECT
-        block_number,
-        state_id,
-        INDEX,
-        array_index,
-        b._inserted_timestamp,
-        {{ dbt_utils.generate_surrogate_key(['block_number', 'index', 'array_index']) }} AS id,
-        s._partition_by_block_id AS _partition_by_block_id,
-        DATA
-    FROM
-        {{ source(
-            'bronze_streamline',
-            'beacon_validators'
-        ) }}
-        s
-        JOIN meta b
-        ON b.file_name = metadata$filename
-        AND b._partition_by_block_id = s._partition_by_block_id
-    WHERE
-        b._partition_by_block_id = s._partition_by_block_id
-        AND (
-            DATA :error :code IS NULL
-            OR DATA :error :code NOT IN (
-                '-32000',
-                '-32001',
-                '-32002',
-                '-32003',
-                '-32004',
-                '-32005',
-                '-32006',
-                '-32007',
-                '-32008',
-                '-32009',
-                '-32010'
-            )
-        )
+{{ fsc_evm.streamline_external_table_query(
+    model = "beacon_validators_v2",
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER)",
+    block_number = false
+) }}

--- a/models/streamline/silver/beacon/complete/streamline__complete_beacon_validators.sql
+++ b/models/streamline/silver/beacon/complete/streamline__complete_beacon_validators.sql
@@ -9,16 +9,14 @@
 ) }}
 
 SELECT
-    {# COALESCE(
+    COALESCE(
         VALUE :"SLOT_NUMBER" :: INT,
         VALUE :"block_number" :: INT
-    ) AS slot_number, --referred to as block_number in FR table #}
-    block_number AS slot_number,
-    {# COALESCE(
+    ) AS slot_number, --referred to as block_number in FR table
+    COALESCE(
         VALUE :"STATE_ID" :: STRING,
         VALUE :"state_id" :: STRING
-    ) AS state_id, #}
-    state_id,
+    ) AS state_id,
     {{ dbt_utils.generate_surrogate_key(
         ['slot_number']
     ) }} AS complete_beacon_validators_id,

--- a/models/streamline/silver/beacon/history/streamline__beacon_blocks_history.sql
+++ b/models/streamline/silver/beacon/history/streamline__beacon_blocks_history.sql
@@ -4,9 +4,9 @@
         func = 'streamline.udf_bulk_rest_api_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"beacon_blocks_v2",
-        "sql_limit" :"100000",
-        "producer_batch_size" :"10000",
-        "worker_batch_size" :"10000",
+        "sql_limit" :"620",
+        "producer_batch_size" :"620",
+        "worker_batch_size" :"310",
         "sql_source" :"{{this.identifier}}",
         "exploded_key": tojson(["data"]) }
     ),

--- a/models/streamline/silver/beacon/history/streamline__beacon_validators_history.sql
+++ b/models/streamline/silver/beacon/history/streamline__beacon_validators_history.sql
@@ -1,12 +1,20 @@
 {{ config (
     materialized = "view",
-    post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_rest_api(object_construct('node_name','quicknode', 'sql_source','{{this.identifier}}', 'external_table','beacon_validators', 'route','validators', 'producer_batch_size', 10,'producer_limit_size', 100, 'worker_batch_size', 1, 'producer_batch_chunks_size', 1))",
-        target = "{{this.schema}}.{{this.identifier}}"
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"beacon_validators_v2",
+        "sql_limit" :"2",
+        "producer_batch_size" :"1",
+        "worker_batch_size" :"1",
+        "sql_source" :"{{this.identifier}}",
+        "exploded_key": tojson(["data"]) }
     ),
     tags = ['streamline_beacon_history']
 ) }}
+
 WITH to_do AS (
+
     SELECT
         slot_number,
         state_id
@@ -21,6 +29,22 @@ WITH to_do AS (
 )
 SELECT
     slot_number,
-    state_id
+    state_id,
+    ROUND(
+        slot_number,
+        -3
+    ) AS partition_key,
+    {{ target.database }}.live.udf_api(
+        'GET',
+        '{service}/{Authentication}/eth/v1/beacon/states/' || state_id || '/validators',
+        OBJECT_CONSTRUCT(
+            'accept',
+            'application/json'
+        ),
+        NULL,
+        'vault/prod/ethereum/quicknode/mainnet'
+    ) AS request
 FROM
     to_do
+ORDER BY
+    slot_number DESC

--- a/models/streamline/silver/beacon/realtime/streamline__beacon_blocks_realtime.sql
+++ b/models/streamline/silver/beacon/realtime/streamline__beacon_blocks_realtime.sql
@@ -4,9 +4,9 @@
         func = 'streamline.udf_bulk_rest_api_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"beacon_blocks_v2",
-        "sql_limit" :"100000",
-        "producer_batch_size" :"10000",
-        "worker_batch_size" :"10000",
+        "sql_limit" :"620",
+        "producer_batch_size" :"620",
+        "worker_batch_size" :"310",
         "sql_source" :"{{this.identifier}}",
         "exploded_key": tojson(["data"]) }
     ),

--- a/models/streamline/silver/beacon/realtime/streamline__beacon_validators_realtime.sql
+++ b/models/streamline/silver/beacon/realtime/streamline__beacon_validators_realtime.sql
@@ -26,7 +26,6 @@ WITH to_do AS (
         state_id
     FROM
         {{ ref("streamline__complete_beacon_validators") }}
-        WHERE slot_number < 9975598 --remove for prod
 ),
 ready_slots AS (
     SELECT

--- a/models/streamline/silver/beacon/realtime/streamline__beacon_validators_realtime.sql
+++ b/models/streamline/silver/beacon/realtime/streamline__beacon_validators_realtime.sql
@@ -1,12 +1,20 @@
 {{ config (
     materialized = "view",
-    post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_rest_api(object_construct('node_name','quicknode', 'sql_source','{{this.identifier}}', 'external_table','beacon_validators', 'route','validators', 'producer_batch_size', 1,'producer_limit_size', 10, 'worker_batch_size', 1, 'producer_batch_chunks_size', 1))",
-        target = "{{this.schema}}.{{this.identifier}}"
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"beacon_validators_v2",
+        "sql_limit" :"2",
+        "producer_batch_size" :"1",
+        "worker_batch_size" :"1",
+        "sql_source" :"{{this.identifier}}",
+        "exploded_key": tojson(["data"]) }
     ),
     tags = ['streamline_beacon_realtime']
 ) }}
+
 WITH to_do AS (
+
     SELECT
         block_number AS slot_number,
         state_id
@@ -18,15 +26,39 @@ WITH to_do AS (
         state_id
     FROM
         {{ ref("streamline__complete_beacon_validators") }}
+        WHERE slot_number < 9975598 --remove for prod
+),
+ready_slots AS (
+    SELECT
+        slot_number,
+        state_id
+    FROM
+        to_do
+    UNION
+    SELECT
+        slot_number,
+        state_id
+    FROM
+        {{ ref("_missing_validators") }}
 )
 SELECT
     slot_number,
-    state_id
+    state_id,
+    ROUND(
+        slot_number,
+        -3
+    ) AS partition_key,
+    {{ target.database }}.live.udf_api(
+        'GET',
+        '{service}/{Authentication}/eth/v1/beacon/states/' || state_id || '/validators',
+        OBJECT_CONSTRUCT(
+            'accept',
+            'application/json'
+        ),
+        NULL,
+        'vault/prod/ethereum/quicknode/mainnet'
+    ) AS request
 FROM
-    to_do
-UNION
-SELECT
-    slot_number,
-    state_id
-FROM
-    {{ ref("_missing_validators") }}
+    ready_slots
+ORDER BY
+    slot_number DESC


### PR DESCRIPTION
1. Reinstates SL 2.0 for Beacon Validators - initially reverted in PRs [951](https://github.com/FlipsideCrypto/ethereum-models/pull/951) and [952](https://github.com/FlipsideCrypto/ethereum-models/pull/952)
3. Updates config params
4. Requires SL multi-processing in prod and `dbt run -m models/streamline/bronze/beacon/bronze__streamline_beacon_validators.sql --full-refresh`