### PR TITLE
AN-5280/sl2-decoded-traces

### DIFF
--- a/models/streamline/bronze/decoder/bronze__streamline_decoded_traces.sql
+++ b/models/streamline/bronze/decoder/bronze__streamline_decoded_traces.sql
@@ -2,5 +2,5 @@
     materialized = 'view'
 ) }}
 {{ fsc_evm.streamline_external_table_query_decoder(
-    model = "decoded_traces"
+    model = "decoded_traces_v2"
 ) }}

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_000049891_004177867.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_000049891_004177867.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_000049891_004177867.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_000049891_004177867.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004177868_004432240.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004177868_004432240.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004177868_004432240.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004177868_004432240.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004432241_004688812.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004432241_004688812.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004432241_004688812.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004432241_004688812.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004688813_004885052.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004688813_004885052.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004688813_004885052.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004688813_004885052.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004885053_005095830.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004885053_005095830.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004885053_005095830.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_004885053_005095830.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005095831_005288563.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005095831_005288563.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005095831_005288563.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005095831_005288563.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005288564_005464728.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005288564_005464728.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005288564_005464728.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005288564_005464728.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005464729_005607688.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005464729_005607688.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005464729_005607688.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005464729_005607688.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005607689_005772096.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005607689_005772096.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005607689_005772096.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005607689_005772096.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005772097_005931710.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005772097_005931710.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005772097_005931710.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005772097_005931710.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005931711_006071218.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005931711_006071218.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005931711_006071218.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_005931711_006071218.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006071219_006238354.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006071219_006238354.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006071219_006238354.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006071219_006238354.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006238355_006381420.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006238355_006381420.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006238355_006381420.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006238355_006381420.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006381421_006539820.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006381421_006539820.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006381421_006539820.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006381421_006539820.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006539821_006734105.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006539821_006734105.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006539821_006734105.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006539821_006734105.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006734106_006882949.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006734106_006882949.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006734106_006882949.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006734106_006882949.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006882950_007041044.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006882950_007041044.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006882950_007041044.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_006882950_007041044.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007041045_007212078.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007041045_007212078.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007041045_007212078.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007041045_007212078.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007212079_007363594.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007212079_007363594.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007212079_007363594.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007212079_007363594.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007363595_007534013.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007363595_007534013.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007363595_007534013.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007363595_007534013.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007534014_007699593.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007534014_007699593.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007534014_007699593.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007534014_007699593.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007699594_007836265.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007699594_007836265.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007699594_007836265.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007699594_007836265.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007836266_007958545.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007836266_007958545.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007836266_007958545.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007836266_007958545.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007958546_008083092.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007958546_008083092.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007958546_008083092.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_007958546_008083092.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008083093_008212874.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008083093_008212874.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008083093_008212874.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008083093_008212874.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008212875_008328130.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008212875_008328130.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008212875_008328130.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008212875_008328130.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008328131_008452645.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008328131_008452645.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008328131_008452645.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008328131_008452645.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008452646_008573782.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008452646_008573782.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008452646_008573782.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008452646_008573782.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008573783_008685896.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008573783_008685896.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008573783_008685896.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008573783_008685896.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008685897_008801965.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008685897_008801965.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008685897_008801965.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008685897_008801965.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008801966_008897858.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008801966_008897858.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008801966_008897858.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008801966_008897858.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008897859_008970649.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008897859_008970649.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008897859_008970649.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008897859_008970649.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008970650_009071228.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008970650_009071228.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008970650_009071228.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_008970650_009071228.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009071229_009178419.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009071229_009178419.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009071229_009178419.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009071229_009178419.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009178420_009296620.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009178420_009296620.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009178420_009296620.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009178420_009296620.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009296621_009412279.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009296621_009412279.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009296621_009412279.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009296621_009412279.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009412280_009487185.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009412280_009487185.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009412280_009487185.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009412280_009487185.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009487186_009576903.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009487186_009576903.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009487186_009576903.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009487186_009576903.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009576904_009661006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009576904_009661006.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009576904_009661006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009576904_009661006.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009661007_009743714.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009661007_009743714.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009661007_009743714.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009661007_009743714.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009743715_009846024.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009743715_009846024.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009743715_009846024.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009743715_009846024.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009846025_009939626.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009846025_009939626.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009846025_009939626.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009846025_009939626.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009939627_010035981.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009939627_010035981.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009939627_010035981.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_009939627_010035981.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010035984_010133318.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010035984_010133318.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010035984_010133318.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010035984_010133318.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010133319_010232060.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010133319_010232060.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010133319_010232060.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010133319_010232060.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010232061_010312829.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010232061_010312829.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010232061_010312829.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010232061_010312829.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010312830_010379609.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010312830_010379609.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010312830_010379609.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010312830_010379609.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010379610_010446851.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010379610_010446851.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010379610_010446851.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010379610_010446851.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010446853_010505645.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010446853_010505645.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010446853_010505645.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010446853_010505645.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010505646_010556936.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010505646_010556936.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010505646_010556936.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010505646_010556936.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010556937_010610651.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010556937_010610651.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010556937_010610651.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010556937_010610651.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010610652_010656159.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010610652_010656159.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010610652_010656159.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010610652_010656159.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010656160_010699717.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010656160_010699717.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010656160_010699717.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010656160_010699717.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010699720_010742434.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010699720_010742434.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010699720_010742434.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010699720_010742434.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010742435_010779787.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010742435_010779787.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010742435_010779787.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010742435_010779787.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010779788_010815937.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010779788_010815937.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010779788_010815937.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010779788_010815937.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010815938_010851330.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010815938_010851330.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010815938_010851330.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010815938_010851330.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010851331_010886601.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010851331_010886601.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010851331_010886601.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010851331_010886601.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010886602_010921114.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010886602_010921114.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010886602_010921114.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010886602_010921114.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010921115_010958038.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010921115_010958038.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010921115_010958038.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010921115_010958038.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010958039_010995784.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010958039_010995784.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010958039_010995784.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010958039_010995784.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010995785_011033365.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010995785_011033365.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010995785_011033365.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_010995785_011033365.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011033366_011074977.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011033366_011074977.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011033366_011074977.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011033366_011074977.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011074978_011114951.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011074978_011114951.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011074978_011114951.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011074978_011114951.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011114952_011155488.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011114952_011155488.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011114952_011155488.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011114952_011155488.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011155489_011196026.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011155489_011196026.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011155489_011196026.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011155489_011196026.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011196027_011237441.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011196027_011237441.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011196027_011237441.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011196027_011237441.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011237442_011278570.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011237442_011278570.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011237442_011278570.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011237442_011278570.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011278571_011317001.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011278571_011317001.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011278571_011317001.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011278571_011317001.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011317002_011358724.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011317002_011358724.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011317002_011358724.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011317002_011358724.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011358725_011396515.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011358725_011396515.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011358725_011396515.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011358725_011396515.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011396516_011432987.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011396516_011432987.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011396516_011432987.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011396516_011432987.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011432988_011471868.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011432988_011471868.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011432988_011471868.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011432988_011471868.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011471869_011509325.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011471869_011509325.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011471869_011509325.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011471869_011509325.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011509326_011546412.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011509326_011546412.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011509326_011546412.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011509326_011546412.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011546413_011584997.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011546413_011584997.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011546413_011584997.sql
+++ b/models/streamline/silver/decoder/history/traces/range_0/streamline__decode_traces_history_011546413_011584997.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_0']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011584998_011627391.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011584998_011627391.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011584998_011627391.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011584998_011627391.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011627392_011667448.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011627392_011667448.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011627392_011667448.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011627392_011667448.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011667449_011706397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011667449_011706397.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011667449_011706397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011667449_011706397.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011706398_011743039.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011706398_011743039.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011706398_011743039.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011706398_011743039.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011743041_011781898.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011743041_011781898.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011743041_011781898.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011743041_011781898.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011781899_011822233.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011781899_011822233.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011781899_011822233.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011781899_011822233.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011822234_011861349.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011822234_011861349.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011822234_011861349.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011822234_011861349.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011861350_011901762.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011861350_011901762.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011861350_011901762.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011861350_011901762.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011901763_011943594.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011901763_011943594.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011901763_011943594.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011901763_011943594.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011943595_011983607.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011943595_011983607.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011943595_011983607.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011943595_011983607.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011983608_012023736.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011983608_012023736.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011983608_012023736.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_011983608_012023736.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012023737_012065799.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012023737_012065799.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012023737_012065799.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012023737_012065799.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012065800_012106368.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012065800_012106368.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012065800_012106368.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012065800_012106368.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012106369_012147269.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012106369_012147269.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012106369_012147269.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012106369_012147269.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012147270_012188006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012147270_012188006.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012147270_012188006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012147270_012188006.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012188007_012229356.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012188007_012229356.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012188007_012229356.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012188007_012229356.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012229357_012269792.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012229357_012269792.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012229357_012269792.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012229357_012269792.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012269793_012306199.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012269793_012306199.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012269793_012306199.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012269793_012306199.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012306200_012339240.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012306200_012339240.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012306200_012339240.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012306200_012339240.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012339241_012371269.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012339241_012371269.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012339241_012371269.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012339241_012371269.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012371270_012403922.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012371270_012403922.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012371270_012403922.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012371270_012403922.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012403923_012437544.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012403923_012437544.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012403923_012437544.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012403923_012437544.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012437545_012467816.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012437545_012467816.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012437545_012467816.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012437545_012467816.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012467817_012496942.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012467817_012496942.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012467817_012496942.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012467817_012496942.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012496943_012527417.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012496943_012527417.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012496943_012527417.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012496943_012527417.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012527418_012559067.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012527418_012559067.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012527418_012559067.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012527418_012559067.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012559068_012591460.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012559068_012591460.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012559068_012591460.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012559068_012591460.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012591461_012622148.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012591461_012622148.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012591461_012622148.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012591461_012622148.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012622149_012653278.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012622149_012653278.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012622149_012653278.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012622149_012653278.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012653279_012683924.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012653279_012683924.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012653279_012683924.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012653279_012683924.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012683925_012715183.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012683925_012715183.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012683925_012715183.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012683925_012715183.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012715184_012748030.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012715184_012748030.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012715184_012748030.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012715184_012748030.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012748031_012779550.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012748031_012779550.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012748031_012779550.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012748031_012779550.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012779551_012810517.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012779551_012810517.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012779551_012810517.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012779551_012810517.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012810518_012841405.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012810518_012841405.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012810518_012841405.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012810518_012841405.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012841406_012872590.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012841406_012872590.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012841406_012872590.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012841406_012872590.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012872591_012903281.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012872591_012903281.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012872591_012903281.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012872591_012903281.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012903282_012935361.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012903282_012935361.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012903282_012935361.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012903282_012935361.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012935362_012968154.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012935362_012968154.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012935362_012968154.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012935362_012968154.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012968155_013001696.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012968155_013001696.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012968155_013001696.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_012968155_013001696.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013001698_013036911.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013001698_013036911.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013001698_013036911.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013001698_013036911.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013036912_013069138.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013036912_013069138.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013036912_013069138.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013036912_013069138.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013069139_013104015.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013069139_013104015.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013069139_013104015.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013069139_013104015.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013104016_013143488.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013104016_013143488.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013104016_013143488.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013104016_013143488.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013143489_013185425.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013143489_013185425.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013143489_013185425.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013143489_013185425.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013185426_013223837.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013185426_013223837.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013185426_013223837.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013185426_013223837.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013223838_013261220.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013223838_013261220.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013223838_013261220.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013223838_013261220.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013261221_013298036.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013261221_013298036.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013261221_013298036.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013261221_013298036.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013298037_013336661.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013298037_013336661.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013298037_013336661.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013298037_013336661.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013336662_013374656.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013336662_013374656.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013336662_013374656.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013336662_013374656.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013374657_013411893.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013374657_013411893.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013374657_013411893.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013374657_013411893.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013411894_013448444.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013411894_013448444.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013411894_013448444.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013411894_013448444.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013448445_013483403.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013448445_013483403.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013448445_013483403.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013448445_013483403.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013483404_013518339.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013483404_013518339.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013483404_013518339.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013483404_013518339.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013518340_013552978.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013518340_013552978.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013518340_013552978.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013518340_013552978.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013552979_013587705.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013552979_013587705.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013552979_013587705.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013552979_013587705.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013587706_013621791.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013587706_013621791.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013587706_013621791.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013587706_013621791.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013621792_013656554.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013621792_013656554.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013621792_013656554.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013621792_013656554.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013656555_013691198.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013656555_013691198.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013656555_013691198.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013656555_013691198.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013691199_013727900.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013691199_013727900.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013691199_013727900.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013691199_013727900.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013727901_013763407.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013727901_013763407.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013727901_013763407.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013727901_013763407.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013763409_013799946.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013763409_013799946.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013763409_013799946.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013763409_013799946.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013799947_013834692.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013799947_013834692.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013799947_013834692.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013799947_013834692.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013834693_013869990.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013834693_013869990.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013834693_013869990.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013834693_013869990.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013869991_013904036.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013869991_013904036.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013869991_013904036.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013869991_013904036.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013904037_013939952.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013904037_013939952.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013904037_013939952.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013904037_013939952.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013939953_013977243.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013939953_013977243.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013939953_013977243.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013939953_013977243.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013977244_014014397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013977244_014014397.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013977244_014014397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_013977244_014014397.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014014398_014049906.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014014398_014049906.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014014398_014049906.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014014398_014049906.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014049907_014083921.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014049907_014083921.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014049907_014083921.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014049907_014083921.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014083922_014122026.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014083922_014122026.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014083922_014122026.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014083922_014122026.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014122027_014158944.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014122027_014158944.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014122027_014158944.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014122027_014158944.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014158946_014194481.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014158946_014194481.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014158946_014194481.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014158946_014194481.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014194482_014229960.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014194482_014229960.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014194482_014229960.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014194482_014229960.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014229961_014265450.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014229961_014265450.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014229961_014265450.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014229961_014265450.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014265451_014300386.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014265451_014300386.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014265451_014300386.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014265451_014300386.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014300387_014334468.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014300387_014334468.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_1']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014300387_014334468.sql
+++ b/models/streamline/silver/decoder/history/traces/range_1/streamline__decode_traces_history_014300387_014334468.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014334469_014368099.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014334469_014368099.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014334469_014368099.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014334469_014368099.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014368100_014402242.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014368100_014402242.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014368100_014402242.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014368100_014402242.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014402243_014434979.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014402243_014434979.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014402243_014434979.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014402243_014434979.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014434980_014468651.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014434980_014468651.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014434980_014468651.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014434980_014468651.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014468652_014500499.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014468652_014500499.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014468652_014500499.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014468652_014500499.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014500500_014530884.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014500500_014530884.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014500500_014530884.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014500500_014530884.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014530885_014563859.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014530885_014563859.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014530885_014563859.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014530885_014563859.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014563860_014596657.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014563860_014596657.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014563860_014596657.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014563860_014596657.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014596658_014630287.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014596658_014630287.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014596658_014630287.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014596658_014630287.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014630288_014663655.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014630288_014663655.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014630288_014663655.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014630288_014663655.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014663656_014696141.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014663656_014696141.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014663656_014696141.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014663656_014696141.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014696142_014728142.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014696142_014728142.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014696142_014728142.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014696142_014728142.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014728143_014758398.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014728143_014758398.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014728143_014758398.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014728143_014758398.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014758399_014788301.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014758399_014788301.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014758399_014788301.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014758399_014788301.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014788303_014823902.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014788303_014823902.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014788303_014823902.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014788303_014823902.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014823903_014860024.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014823903_014860024.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014823903_014860024.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014823903_014860024.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014860025_014898979.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014860025_014898979.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014860025_014898979.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014860025_014898979.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014898980_014938011.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014898980_014938011.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014898980_014938011.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014898980_014938011.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014938012_014970420.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014938012_014970420.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014938012_014970420.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014938012_014970420.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014970421_015007131.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014970421_015007131.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014970421_015007131.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_014970421_015007131.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015007132_015045564.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015007132_015045564.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015007132_015045564.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015007132_015045564.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015045565_015083629.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015045565_015083629.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015045565_015083629.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015045565_015083629.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015083630_015122944.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015083630_015122944.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015083630_015122944.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015083630_015122944.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015122945_015162787.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015122945_015162787.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015122945_015162787.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015122945_015162787.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015162788_015198836.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015162788_015198836.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015162788_015198836.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015162788_015198836.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015198837_015236319.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015198837_015236319.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015198837_015236319.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015198837_015236319.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015236320_015272031.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015236320_015272031.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015236320_015272031.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015236320_015272031.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015272032_015309289.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015272032_015309289.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015272032_015309289.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015272032_015309289.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015309290_015343885.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015309290_015343885.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015309290_015343885.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015309290_015343885.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015343886_015378738.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015343886_015378738.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015343886_015378738.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015343886_015378738.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015378739_015413213.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015378739_015413213.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015378739_015413213.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015378739_015413213.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015413214_015448194.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015413214_015448194.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015413214_015448194.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015413214_015448194.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015448195_015484901.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015448195_015484901.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015448195_015484901.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015448195_015484901.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015484902_015518888.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015484902_015518888.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015484902_015518888.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015484902_015518888.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015518889_015554747.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015518889_015554747.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015518889_015554747.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015518889_015554747.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015554748_015589894.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015554748_015589894.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015554748_015589894.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015554748_015589894.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015589895_015623345.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015589895_015623345.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015589895_015623345.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015589895_015623345.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015623346_015657758.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015623346_015657758.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015623346_015657758.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015623346_015657758.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015657759_015692627.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015657759_015692627.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015657759_015692627.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015657759_015692627.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015692628_015733090.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015692628_015733090.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015692628_015733090.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015692628_015733090.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015733091_015770086.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015733091_015770086.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015733091_015770086.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015733091_015770086.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015770087_015804823.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015770087_015804823.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015770087_015804823.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015770087_015804823.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015804824_015840212.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015804824_015840212.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015804824_015840212.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015804824_015840212.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015840213_015876166.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015840213_015876166.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015840213_015876166.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015840213_015876166.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015876167_015912388.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015876167_015912388.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015876167_015912388.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015876167_015912388.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015912389_015945115.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015912389_015945115.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015912389_015945115.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015912389_015945115.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015945116_015980705.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015945116_015980705.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015945116_015980705.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015945116_015980705.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015980706_016017657.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015980706_016017657.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015980706_016017657.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_015980706_016017657.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016017658_016055430.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016017658_016055430.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016017658_016055430.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016017658_016055430.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016055431_016092268.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016055431_016092268.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016055431_016092268.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016055431_016092268.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016092269_016129688.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016092269_016129688.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016092269_016129688.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016092269_016129688.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016129689_016169317.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016129689_016169317.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016129689_016169317.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016129689_016169317.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016169318_016205421.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016169318_016205421.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016169318_016205421.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016169318_016205421.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016205422_016242125.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016205422_016242125.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016205422_016242125.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016205422_016242125.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016242126_016279992.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016242126_016279992.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016242126_016279992.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016242126_016279992.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016279993_016315398.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016279993_016315398.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016279993_016315398.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016279993_016315398.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016315399_016349762.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016315399_016349762.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016315399_016349762.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016315399_016349762.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016349763_016384301.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016349763_016384301.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016349763_016384301.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016349763_016384301.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016384302_016417876.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016384302_016417876.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016384302_016417876.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016384302_016417876.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016417877_016451946.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016417877_016451946.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016417877_016451946.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016417877_016451946.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016451947_016486109.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016451947_016486109.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016451947_016486109.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016451947_016486109.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016486110_016519759.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016486110_016519759.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016486110_016519759.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016486110_016519759.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016519760_016552056.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016519760_016552056.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016519760_016552056.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016519760_016552056.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016552057_016582976.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016552057_016582976.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016552057_016582976.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016552057_016582976.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016582977_016615072.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016582977_016615072.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016582977_016615072.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016582977_016615072.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016615073_016647493.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016615073_016647493.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016615073_016647493.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016615073_016647493.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016647494_016678959.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016647494_016678959.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016647494_016678959.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016647494_016678959.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016678960_016712187.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016678960_016712187.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016678960_016712187.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016678960_016712187.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016712188_016745332.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016712188_016745332.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016712188_016745332.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016712188_016745332.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016745333_016777942.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016745333_016777942.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016745333_016777942.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016745333_016777942.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016777943_016808424.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016777943_016808424.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016777943_016808424.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016777943_016808424.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016808425_016840600.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016808425_016840600.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016808425_016840600.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016808425_016840600.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016840601_016874548.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016840601_016874548.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016840601_016874548.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016840601_016874548.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016874549_016909666.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016874549_016909666.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016874549_016909666.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016874549_016909666.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016909667_016944644.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016909667_016944644.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016909667_016944644.sql
+++ b/models/streamline/silver/decoder/history/traces/range_2/streamline__decode_traces_history_016909667_016944644.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_2']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016944645_016980513.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016944645_016980513.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016944645_016980513.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016944645_016980513.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016980514_017017763.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016980514_017017763.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016980514_017017763.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_016980514_017017763.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017017764_017055258.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017017764_017055258.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017017764_017055258.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017017764_017055258.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017055259_017085808.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017055259_017085808.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017055259_017085808.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017055259_017085808.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017085809_017116307.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017085809_017116307.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017085809_017116307.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017085809_017116307.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017116308_017148805.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017116308_017148805.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017116308_017148805.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017116308_017148805.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017148806_017177111.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017148806_017177111.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017148806_017177111.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017148806_017177111.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017177112_017204093.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017177112_017204093.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017177112_017204093.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017177112_017204093.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017204094_017230543.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017204094_017230543.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017204094_017230543.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017204094_017230543.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017230544_017259339.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017230544_017259339.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017230544_017259339.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017230544_017259339.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017259340_017290006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017259340_017290006.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017259340_017290006.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017259340_017290006.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017290007_017320757.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017290007_017320757.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017290007_017320757.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017290007_017320757.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017320758_017351620.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017320758_017351620.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017320758_017351620.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017320758_017351620.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017351621_017382307.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017351621_017382307.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017351621_017382307.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017351621_017382307.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017382308_017414889.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017382308_017414889.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017382308_017414889.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017382308_017414889.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017414890_017448025.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017414890_017448025.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017414890_017448025.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017414890_017448025.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017448026_017483349.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017448026_017483349.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017448026_017483349.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017448026_017483349.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017483350_017518219.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017483350_017518219.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017483350_017518219.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017483350_017518219.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017518220_017552880.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017518220_017552880.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017518220_017552880.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017518220_017552880.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017552881_017587226.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017552881_017587226.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017552881_017587226.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017552881_017587226.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017587227_017619679.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017587227_017619679.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017587227_017619679.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017587227_017619679.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017619680_017655387.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017619680_017655387.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017619680_017655387.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017619680_017655387.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017655388_017687261.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017655388_017687261.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017655388_017687261.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017655388_017687261.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017687262_017718369.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017687262_017718369.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017687262_017718369.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017687262_017718369.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017718370_017748817.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017718370_017748817.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017718370_017748817.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017718370_017748817.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017748818_017779606.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017748818_017779606.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017748818_017779606.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017748818_017779606.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017779607_017811317.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017779607_017811317.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017779607_017811317.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017779607_017811317.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017811318_017843278.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017811318_017843278.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017811318_017843278.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017811318_017843278.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017843279_017875882.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017843279_017875882.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017843279_017875882.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017843279_017875882.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017875883_017907427.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017875883_017907427.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017875883_017907427.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017875883_017907427.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017907428_017938609.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017907428_017938609.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017907428_017938609.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017907428_017938609.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017938610_017969936.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017938610_017969936.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017938610_017969936.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017938610_017969936.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017969937_018001222.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017969937_018001222.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017969937_018001222.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_017969937_018001222.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018001223_018032975.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018001223_018032975.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018001223_018032975.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018001223_018032975.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018032976_018065505.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018032976_018065505.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018032976_018065505.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018032976_018065505.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018065506_018098242.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018065506_018098242.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018065506_018098242.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018065506_018098242.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018098243_018132589.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018098243_018132589.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018098243_018132589.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018098243_018132589.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018132590_018166155.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018132590_018166155.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018132590_018166155.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018132590_018166155.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018166156_018201098.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018166156_018201098.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018166156_018201098.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018166156_018201098.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018201099_018235604.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018201099_018235604.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018201099_018235604.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018201099_018235604.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018235605_018268614.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018235605_018268614.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018235605_018268614.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018235605_018268614.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018268615_018302451.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018268615_018302451.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018268615_018302451.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018268615_018302451.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018302452_018336025.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018302452_018336025.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018302452_018336025.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018302452_018336025.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018336026_018369103.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018336026_018369103.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018336026_018369103.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018336026_018369103.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018369104_018401321.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018369104_018401321.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018369104_018401321.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018369104_018401321.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018401322_018433184.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018401322_018433184.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018401322_018433184.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018401322_018433184.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018433185_018465329.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018433185_018465329.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018433185_018465329.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018433185_018465329.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018465330_018497002.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018465330_018497002.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018465330_018497002.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018465330_018497002.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018497003_018529131.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018497003_018529131.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018497003_018529131.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018497003_018529131.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018529132_018560397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018529132_018560397.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018529132_018560397.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018529132_018560397.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018560398_018591902.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018560398_018591902.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018560398_018591902.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018560398_018591902.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018591903_018624780.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018591903_018624780.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018591903_018624780.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018591903_018624780.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018624781_018657912.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018624781_018657912.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018624781_018657912.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018624781_018657912.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018657913_018689816.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018657913_018689816.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018657913_018689816.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018657913_018689816.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018689817_018721636.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018689817_018721636.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018689817_018721636.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018689817_018721636.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018721637_018754169.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018721637_018754169.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018721637_018754169.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018721637_018754169.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018754170_018788478.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018754170_018788478.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018754170_018788478.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018754170_018788478.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018788479_018823449.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018788479_018823449.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018788479_018823449.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018788479_018823449.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018823450_018857493.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018823450_018857493.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018823450_018857493.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018823450_018857493.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018857494_018891457.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018857494_018891457.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018857494_018891457.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018857494_018891457.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018891458_018924528.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018891458_018924528.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018891458_018924528.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018891458_018924528.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018908895_018943246.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018908895_018943246.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018908895_018943246.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018908895_018943246.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018924529_018960175.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018924529_018960175.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018924529_018960175.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018924529_018960175.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018960176_018994533.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018960176_018994533.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018960176_018994533.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018960176_018994533.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018994534_019028739.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018994534_019028739.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018994534_019028739.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_018994534_019028739.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019028740_019060181.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019028740_019060181.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019028740_019060181.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019028740_019060181.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019060182_019091516.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019060182_019091516.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019060182_019091516.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019060182_019091516.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019091517_019123294.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019091517_019123294.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019091517_019123294.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019091517_019123294.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019123295_019152984.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019123295_019152984.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019123295_019152984.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019123295_019152984.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019152985_019185098.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019152985_019185098.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019152985_019185098.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019152985_019185098.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019185099_019220258.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019185099_019220258.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019185099_019220258.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019185099_019220258.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019220259_019253234.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019220259_019253234.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019220259_019253234.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019220259_019253234.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019253235_019288083.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019253235_019288083.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019253235_019288083.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019253235_019288083.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019288084_019321848.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019288084_019321848.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019288084_019321848.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019288084_019321848.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019321849_019355542.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019321849_019355542.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019321849_019355542.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019321849_019355542.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019355543_019378189.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019355543_019378189.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019355543_019378189.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019355543_019378189.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019378190_019428190.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019378190_019428190.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019378190_019428190.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019378190_019428190.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019428191_019478191.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019428191_019478191.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019428191_019478191.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019428191_019478191.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019478192_019528192.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019478192_019528192.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019478192_019528192.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019478192_019528192.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019528193_019578193.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019528193_019578193.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019528193_019578193.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019528193_019578193.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019578194_019628194.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019578194_019628194.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019578194_019628194.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019578194_019628194.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019628195_019678195.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019628195_019678195.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019628195_019678195.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019628195_019678195.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019678196_019728196.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019678196_019728196.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019678196_019728196.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019678196_019728196.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019728197_019778197.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019728197_019778197.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019728197_019778197.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019728197_019778197.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019778198_019828198.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019778198_019828198.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019778198_019828198.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019778198_019828198.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019828199_019878199.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019828199_019878199.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019828199_019878199.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019828199_019878199.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019878200_019928200.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019878200_019928200.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019878200_019928200.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019878200_019928200.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019928201_019978201.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019928201_019978201.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019928201_019978201.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019928201_019978201.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019978202_020028202.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019978202_020028202.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019978202_020028202.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_019978202_020028202.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020028203_020078203.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020028203_020078203.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020028203_020078203.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020028203_020078203.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020078204_020128204.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020078204_020128204.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020078204_020128204.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020078204_020128204.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020128205_020178205.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020128205_020178205.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020128205_020178205.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020128205_020178205.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020178206_020228206.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020178206_020228206.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020178206_020228206.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020178206_020228206.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020228207_020278207.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020228207_020278207.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020228207_020278207.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020228207_020278207.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020278208_020328208.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020278208_020328208.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020278208_020328208.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020278208_020328208.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020328209_020378209.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020328209_020378209.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020328209_020378209.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020328209_020378209.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020378210_020428210.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020378210_020428210.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020378210_020428210.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020378210_020428210.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020428211_020478211.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020428211_020478211.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020428211_020478211.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020428211_020478211.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020478212_020528212.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020478212_020528212.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020478212_020528212.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020478212_020528212.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020528213_020578213.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020528213_020578213.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020528213_020578213.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020528213_020578213.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020578214_020628214.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020578214_020628214.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020578214_020628214.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020578214_020628214.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020628215_020678215.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020628215_020678215.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020628215_020678215.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020628215_020678215.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020678216_020728216.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020678216_020728216.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020678216_020728216.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020678216_020728216.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020728217_020778217.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020728217_020778217.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020728217_020778217.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020728217_020778217.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020778218_020828218.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020778218_020828218.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020778218_020828218.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020778218_020828218.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020828219_020878219.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020828219_020878219.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020828219_020878219.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020828219_020878219.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020878220_020928220.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020878220_020928220.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020878220_020928220.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020878220_020928220.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020928221_020978221.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020928221_020978221.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020928221_020978221.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020928221_020978221.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020978222_021028222.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020978222_021028222.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020978222_021028222.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_020978222_021028222.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021028223_021078223.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021028223_021078223.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021028223_021078223.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021028223_021078223.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021078224_021128224.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021078224_021128224.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021078224_021128224.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021078224_021128224.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021128225_021178225.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021128225_021178225.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021128225_021178225.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021128225_021178225.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021178226_021228226.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021178226_021228226.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021178226_021228226.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021178226_021228226.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021228227_021278227.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021228227_021278227.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021228227_021278227.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021228227_021278227.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021278228_021328228.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021278228_021328228.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021278228_021328228.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021278228_021328228.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021328229_021378229.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021328229_021378229.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021328229_021378229.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021328229_021378229.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021378230_021428230.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021378230_021428230.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021378230_021428230.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021378230_021428230.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021428231_021478231.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021428231_021478231.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021428231_021478231.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021428231_021478231.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021478232_021528232.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021478232_021528232.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021478232_021528232.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021478232_021528232.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021528233_021578233.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021528233_021578233.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021528233_021578233.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021528233_021578233.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021578234_021628234.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021578234_021628234.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021578234_021628234.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021578234_021628234.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021628235_021678235.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021628235_021678235.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021628235_021678235.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021628235_021678235.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021678236_021728236.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021678236_021728236.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021678236_021728236.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021678236_021728236.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021728237_021778237.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021728237_021778237.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 10000000))", target = "{{this.schema}}.{{this.identifier}}" ),if_data_call_wait()],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_history_range_3']
 ) }}
 

--- a/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021728237_021778237.sql
+++ b/models/streamline/silver/decoder/history/traces/range_3/streamline__decode_traces_history_021728237_021778237.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
+++ b/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = [fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_traces',
+        func = 'streamline.udf_bulk_decode_traces_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"DECODED_TRACES", 
         "sql_limit" :"20000000",

--- a/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
+++ b/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
@@ -1,6 +1,15 @@
 {{ config (
     materialized = "view",
-    post_hook = [if_data_call_function( func = "{{this.schema}}.udf_bulk_decode_traces(object_construct('sql_source', '{{this.identifier}}','producer_batch_size', 500000,'producer_limit_size', 20000000))", target = "{{this.schema}}.{{this.identifier}}" ),"call system$wait(" ~ var("WAIT", 400) ~ ")" ],
+    post_hook = [fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_decode_traces',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"DECODED_TRACES", 
+        "sql_limit" :"20000000",
+        "producer_batch_size" :"500000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}" }
+    ),
+    fsc_utils.if_data_call_wait()],
     tags = ['streamline_decoded_traces_realtime']
 ) }}
 {{ fsc_evm.streamline_decoded_traces_requests(


### PR DESCRIPTION
Requires updated [ETH SL Runtime Version](https://github.com/FlipsideCrypto/streamline/pull/268)
`dbt run -m models/streamline/bronze/decoder/bronze__streamline_decoded_traces.sql --full-refresh`