### PR TITLE
add stale to compound market stats

### DIFF
--- a/models/silver/defi/lending/compound/silver__comp_market_stats.sql
+++ b/models/silver/defi/lending/compound/silver__comp_market_stats.sql
@@ -3,8 +3,9 @@
     unique_key = 'id',
     cluster_by = ['_inserted_timestamp::date'],
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['curated']
+    tags = ['stale']
 ) }}
+
 WITH market_reads AS (
 
     SELECT


### PR DESCRIPTION
we've already removed the gold table, and no other models rely on this. Will be dropping this table after offsite