### PR TITLE
add otherdeed expanded to backdoor

### DIFF
--- a/models/bronze/api_udf/nft/bronze_api__nft_metadata_list_backdoor.sql
+++ b/models/bronze/api_udf/nft/bronze_api__nft_metadata_list_backdoor.sql
@@ -4,8 +4,8 @@
 ) }}
 
 SELECT
-    '0x23581767a106ae21c074b2276D25e5C3e136a68b' AS nft_address,
-    10000 AS mint_count,
+    '0x790b2cf29ed4f310bf7641f013c65d4560d28371' AS nft_address,
+    55142 AS mint_count,
     1 AS start_page,
     CEIL(
         mint_count / 100


### PR DESCRIPTION
- yuga request to update metadata since metadata has changed 

- requires `delete from ethereum_dev.silver.nft_collection_metadata
where nft_address = '0x790b2cf29ed4f310bf7641f013c65d4560d28371'` before merging 