### PR TITLE
modify child logic for decoded traces

### DIFF
--- a/macros/decoder/decoded_traces_history.sql
+++ b/macros/decoder/decoded_traces_history.sql
@@ -135,7 +135,12 @@
                                     AND trace_address != 'ORIGIN' THEN trace_address || '_'
                                     ELSE NULL
                                 END AS parent_of,
-                                IFF(REGEXP_REPLACE(trace_address, '.$', '') = '', 'ORIGIN', REGEXP_REPLACE(trace_address, '.$', '')) AS child_of,
+                                IFF(REGEXP_REPLACE(trace_address, '[0-9]+$', '') = '', 'ORIGIN', REGEXP_REPLACE(trace_address, '[0-9]+$', '')) AS child_of_raw,
+                                IFF(
+                                    trace_address = 'ORIGIN',
+                                    'ORIGI',
+                                    child_of_raw
+                                ) AS child_of,
                                 input,
                                 output,
                                 concat_ws(

--- a/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
+++ b/models/streamline/silver/decoder/realtime/streamline__decode_traces_realtime.sql
@@ -39,8 +39,8 @@ WITH look_back AS (
                 AND trace_address != 'ORIGIN' THEN trace_address || '_'
                 ELSE NULL
             END AS parent_of,
-            IFF(REGEXP_REPLACE(trace_address, '.$', '') = '', 'ORIGIN', REGEXP_REPLACE(trace_address, '.$', '')) AS child_of,
-            
+            IFF(REGEXP_REPLACE(trace_address, '[0-9]+$', '') = '', 'ORIGIN', REGEXP_REPLACE(trace_address, '[0-9]+$', '')) AS child_of_raw, 
+            iff(trace_address = 'ORIGIN', 'ORIGI', child_of_raw) as child_of, 
             input,
             output,
             concat_ws(


### PR DESCRIPTION
modify child of logic so that last number in trace address which are not single digits gets joined in correctly with parents. Super low impact so no traces reloading is necessary 

child -> parent mapping 
trace origin -> origi 
trace 0 -> origin 
trace 0_10 -> 0 