### PR TITLE
AN-5684/sol-addr-decoding

### DIFF
--- a/data/silver_bridge__allbridge_chain_id_seed.csv
+++ b/data/silver_bridge__allbridge_chain_id_seed.csv
@@ -1,0 +1,12 @@
+chain,chain_id
+ethereum,1
+bsc,2
+tron,3
+solana,4
+polygon,5
+arbitrum,6
+stellar,7
+avalanche,8
+base,9
+optimism,10
+celo,11

--- a/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
+++ b/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
@@ -152,7 +152,7 @@ SELECT
     s._inserted_timestamp
 FROM
     base_evt s
-    LEFT JOIN lp_evt lp
+    INNER JOIN lp_evt lp
     ON s.tx_hash = lp.tx_hash
     AND s.block_number = lp.block_number
     LEFT JOIN {{ ref('silver_bridge__allbridge_chain_id_seed') }} C

--- a/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
+++ b/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
@@ -156,4 +156,6 @@ FROM
     ON s.tx_hash = lp.tx_hash
     AND s.block_number = lp.block_number
     LEFT JOIN {{ ref('silver_bridge__allbridge_chain_id_seed') }} C
-    ON s.destinationChainId = C.chain_id
+    ON s.destinationChainId = C.chain_id qualify(ROW_NUMBER() over (PARTITION BY s._log_id
+ORDER BY
+    s._inserted_timestamp DESC)) = 1

--- a/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
+++ b/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql
@@ -1,0 +1,159 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH base_evt AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'allbridge' AS platform,
+        event_index,
+        'TokensSent' AS event_name,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [0] :: STRING)) AS amount,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [2] :: STRING)) AS destinationChainId,
+        origin_from_address AS sender,
+        origin_from_address AS recipient,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [4] :: STRING)) AS nonce,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [5] :: STRING)) AS messenger,
+        CASE
+            WHEN tx_status = 'SUCCESS' THEN TRUE
+            ELSE FALSE
+        END AS tx_succeeded,
+        CONCAT(
+            tx_hash,
+            '-',
+            event_index
+        ) AS _log_id,
+        modified_timestamp AS _inserted_timestamp
+    FROM
+        {{ ref('core__fact_event_logs') }}
+    WHERE
+        topics [0] = '0x9cd6008e8d4ebd34fd9d022278fec7f95d133780ecc1a0dea459fae3e9675390' --TokensSent
+        AND contract_address = '0x609c690e8f7d68a59885c9132e812eebdaaf0c9e' --Allbridge
+        AND tx_succeeded
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+AND _inserted_timestamp >= SYSDATE() - INTERVAL '7 day'
+{% endif %}
+),
+lp_evt AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        event_index,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS sender,
+        CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS token,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [2] :: STRING)) AS amount,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [3] :: STRING)) AS vUsdAmount,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(segmented_data [4] :: STRING)) AS fee,
+        CASE
+            WHEN tx_status = 'SUCCESS' THEN TRUE
+            ELSE FALSE
+        END AS tx_succeeded,
+        CONCAT(
+            tx_hash,
+            '-',
+            event_index
+        ) AS _log_id,
+        modified_timestamp AS _inserted_timestamp
+    FROM
+        {{ ref('core__fact_event_logs') }}
+    WHERE
+        topics [0] = '0xa930da1d3f27a25892307dd59cec52dd9b881661a0f20364757f83a0da2f6873' --SwappedToVUsd
+        AND contract_address IN (
+            '0x7dbf07ad92ed4e26d5511b4f285508ebf174135d',
+            --USDT LP
+            '0xa7062bba94c91d565ae33b893ab5dfaf1fc57c4d' --USDC LP
+        )
+        AND tx_hash IN (
+            SELECT
+                tx_hash
+            FROM
+                base_evt
+        )
+        AND tx_succeeded
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+AND _inserted_timestamp >= SYSDATE() - INTERVAL '7 day'
+{% endif %}
+)
+SELECT
+    s.block_number,
+    s.block_timestamp,
+    s.tx_hash,
+    s.origin_function_signature,
+    s.origin_from_address,
+    s.origin_to_address,
+    s.contract_address AS bridge_address,
+    s.event_index,
+    s.event_name,
+    s.platform,
+    lp.amount,
+    lp.token AS token_address,
+    s.sender,
+    s.recipient AS receiver,
+    C.chain AS destination_chain,
+    s.destinationChainId AS destination_chain_id,
+    CASE
+        WHEN C.chain = 'solana' THEN utils.udf_hex_to_base58(CONCAT('0x', s.segmented_data [1] :: STRING))
+        WHEN C.chain = 'stellar' THEN s.segmented_data [1] :: STRING
+        ELSE CONCAT(
+            '0x',
+            SUBSTR(
+                s.segmented_data [1] :: STRING,
+                25,
+                40
+            )
+        )
+    END AS destination_chain_receiver,
+    CASE
+        WHEN C.chain = 'solana' THEN utils.udf_hex_to_base58(CONCAT('0x', s.segmented_data [3] :: STRING))
+        WHEN C.chain = 'stellar' THEN s.segmented_data [3] :: STRING
+        ELSE CONCAT(
+            '0x',
+            SUBSTR(
+                s.segmented_data [3] :: STRING,
+                25,
+                40
+            )
+        )
+    END AS destination_chain_token,
+    s.tx_succeeded,
+    s._log_id,
+    s._inserted_timestamp
+FROM
+    base_evt s
+    LEFT JOIN lp_evt lp
+    ON s.tx_hash = lp.tx_hash
+    AND s.block_number = lp.block_number
+    LEFT JOIN {{ ref('silver_bridge__allbridge_chain_id_seed') }} C
+    ON s.destinationChainId = C.chain_id

--- a/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.yml
+++ b/models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.yml
@@ -1,0 +1,69 @@
+version: 2
+models:
+  - name: silver_bridge__allbridge_tokens_sent
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: EVENT_NAME
+        tests:
+          - not_null
+      - name: BRIDGE_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: RECEIVER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: DESTINATION_CHAIN_RECEIVER
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+


### PR DESCRIPTION
1. Adds base58 udf for solana destinations in dln_bridge
2. Adds new protocol version for allbridge

`dbt seed -m silver_bridge__allbridge_chain_id_seed && dbt run -m models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql models/silver/defi/bridge/allbridge/silver_bridge__allbridge_tokens_sent.sql --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql --vars '{"HEAL_MODELS":["dln_debridge","allbridge_v2"]}'`