### PR TITLE
AN-5770/ronin-bridge-addr

### DIFF
--- a/data/silver_bridge__native_bridges_seed.csv
+++ b/data/silver_bridge__native_bridges_seed.csv
@@ -15,7 +15,6 @@ contract_address,contract_name,blockchain
 0x401f6c983ea34274ec46f84d70b31c151321188b,Polygon (Matic): Plasma Bridge,Polygon Mainnet
 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe,Polygon (Matic): zkEVM Bridge,Polygon Mainnet
 0x1a2a1c938ce3ec39b6d47113c7955baa9dd454f2,Axie Infinity: Ronin Bridge,Ronin
-0x64192819ac13ef72bf6b5ae239ac672b43a9af08,Axie Infinity: Ronin Bridge V2,Ronin
 0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419,StarkNet: StarkGate ETH Bridge,Starknet
 0x32400084C286CF3E17e7B677ea9583e60a000324,zkSync Era: Diamond Proxy,zkSync Era Mainnet
 0xabea9132b05a70803a4e85094fd0e1800777fbef,zkSync Lite: Bridge,zkSync Lite

--- a/data/silver_bridge__standard_dst_chain_seed.csv
+++ b/data/silver_bridge__standard_dst_chain_seed.csv
@@ -80,6 +80,7 @@ sei,sei
 skale europa,skale europa
 skale nebula,skale nebula
 solana,solana
+sonic mainnet,sonic
 stargaze,stargaze
 starknet,starknet
 sui,sui

--- a/data/silver_bridge__standard_dst_chain_seed.csv
+++ b/data/silver_bridge__standard_dst_chain_seed.csv
@@ -60,10 +60,12 @@ nautilus,nautilus
 near,near
 neutron,neutron
 oasis,oasis
+oasys mainnet,oasys
 okxchain mainnet,okxchain
 ontology mainnet,ontology
 op mainnet,optimism
 opbnb,opbnb
+opbnb mainnet,opbnb
 optimism,optimism
 osmosis,osmosis
 polygon,polygon

--- a/data/silver_bridge__standard_dst_chain_seed.csv
+++ b/data/silver_bridge__standard_dst_chain_seed.csv
@@ -70,6 +70,7 @@ polygon,polygon
 polygon mainnet,polygon
 polygon pos,polygon
 polygon zkevm,polygon zkevm
+publicmint mainnet,ronin
 ronin,ronin
 scroll,scroll
 secret-snip,secret
@@ -90,6 +91,7 @@ umee,umee
 waves,waves
 xpla,xpla
 xrpl,xrpl
+zetachain mainnet,zetachain
 zkfair,zkfair
 zksync era,zksync era
 zksync era mainnet,zksync era

--- a/models/silver/defi/bridge/axie/silver_bridge__axie_infinity_depositrequested.sql
+++ b/models/silver/defi/bridge/axie/silver_bridge__axie_infinity_depositrequested.sql
@@ -1,0 +1,76 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH base_evt AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'axie_infinity' AS NAME,
+        event_index,
+        topics [0] :: STRING AS topic_0,
+        event_name,
+        TRY_TO_NUMBER(
+            decoded_log :"receipt" :"info" :"quantity" :: STRING
+        ) AS amount,
+        TRY_TO_NUMBER(
+            decoded_log :"receipt" :"ronin" :"chainId" :: STRING
+        ) AS chainId,
+        decoded_log :"receipt" :"mainchain" :"addr" :: STRING AS sender,
+        decoded_log :"receipt" :"ronin" :"addr" :: STRING AS receiver,
+        decoded_log :"receipt" :"mainchain" :"tokenAddr" :: STRING AS token_address,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
+        modified_timestamp AS _inserted_timestamp
+    FROM
+        {{ ref('core__ez_decoded_event_logs') }}
+    WHERE
+        topics [0] :: STRING = '0xd7b25068d9dc8d00765254cfb7f5070f98d263c8d68931d937c7362fa738048b' -- DepositRequested
+        AND contract_address = '0x64192819ac13ef72bf6b5ae239ac672b43a9af08' -- Axie Infinity: Ronin Bridge V2
+        AND tx_succeeded
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+AND _inserted_timestamp >= SYSDATE() - INTERVAL '7 day'
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    topic_0,
+    event_name,
+    contract_address AS bridge_address,
+    NAME AS platform,
+    sender,
+    receiver,
+    receiver AS destination_chain_receiver,
+    amount,
+    chainId AS destination_chain_id,
+    token_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    base_evt

--- a/models/silver/defi/bridge/axie/silver_bridge__axie_infinity_depositrequested.yml
+++ b/models/silver/defi/bridge/axie/silver_bridge__axie_infinity_depositrequested.yml
@@ -1,0 +1,74 @@
+version: 2
+models:
+  - name: silver_bridge__axie_infinity_depositrequested
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: EVENT_NAME
+        tests:
+          - not_null
+      - name: BRIDGE_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: RECEIVER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: DESTINATION_CHAIN_RECEIVER
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -154,6 +154,42 @@ WHERE
     )
 {% endif %}
 ),
+axie_infinity_v2 AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        tx_hash,
+        event_index,
+        bridge_address,
+        event_name,
+        platform,
+        'v2' AS version,
+        sender,
+        receiver,
+        destination_chain_receiver,
+        destination_chain_id :: STRING AS destination_chain_id,
+        NULL AS destination_chain,
+        token_address,
+        NULL AS token_symbol,
+        amount AS amount_unadj,
+        _log_id AS _id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver_bridge__axie_infinity_depositrequested') }}
+
+{% if is_incremental() and 'axie_infinity_v2' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
 axelar AS (
     SELECT
         block_number,
@@ -606,6 +642,11 @@ all_protocols AS (
         *
     FROM
         allbridge_v2
+    UNION ALL
+    SELECT
+        *
+    FROM
+        axie_infinity_v2
     UNION ALL
     SELECT
         *


### PR DESCRIPTION
Splits axie into own bridge model via logs
Requires delete from seed, silver and crosschain

1. Run delete statements to remove axie bridge v2 from native tables and avoid double counting: `ethereum.silver_bridge.native_bridges_seed`, `ethereum.silver_bridge.native_bridges_transfers_out`, `ethereum.silver_bridge.complete_bridge_activity`, `crosschain.silver.complete_bridge_activity`
2. `dbt seed -m silver_bridge__standard_dst_chain_seed && dbt run -m models/silver/defi/bridge/axie/silver_bridge__axie_infinity_depositrequested.sql --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql models/gold/defi/defi__ez_bridge_activity.sql --vars '{"HEAL_MODELS":"axie_infinity_v2"}'`