### PR TITLE
incremental change for blend loans

### DIFF
--- a/models/silver/nft/lending/blur/silver_nft__blend_loans.sql
+++ b/models/silver/nft/lending/blur/silver_nft__blend_loans.sql
@@ -56,11 +56,19 @@ loan_offer_taken_details AS (
 
 {% if is_incremental() %}
 WHERE
-    _inserted_timestamp >= (
+    block_number IN (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '12 hours'
+            DISTINCT block_number
         FROM
-            {{ this }}
+            {{ ref('core__ez_decoded_event_logs') }}
+        WHERE
+            _inserted_timestamp >= (
+                SELECT
+                    MAX(_inserted_timestamp) - INTERVAL '12 hours'
+                FROM
+                    {{ this }}
+            )
+            AND _inserted_timestamp >= SYSDATE() - INTERVAL '7 day'
     )
 {% endif %}
 ),


### PR DESCRIPTION
- issue is in decoded event log, a single block can have multiple txs with different inserted timestamps and because UK is block number, it's possible that txs are not replaced when block number is deleted and inserted 

- this change ensures we load in all events by block number instead of just inserted timestamp 