### PR TITLE
update/makefile-schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ deploy_gha_tasks:
 
 deploy_new_gha_tasks:
 	@set -e; \
+	dbt run-operation fsc_evm.drop_github_actions_schema; \
 	make deploy_gha_workflows_table DBT_TARGET=$(DBT_TARGET); \
 	dbt run -m "fsc_evm,tag:gha_tasks" --full-refresh -t $(DBT_TARGET); \
 	dbt run-operation fsc_evm.create_gha_tasks --vars '{"RESUME_GHA_TASKS":True}' -t $(DBT_TARGET)

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v4.0.0-beta.78
+    revision: v4.0.0-beta.79


### PR DESCRIPTION
Requires new version tag from [fsc-evm PR](https://github.com/FlipsideCrypto/fsc-evm/pull/240/files)

1. Run `dbt_deploy_new_workflows` after merging
2. Suspend `dbt_run_scheduled_scores` by running `dbt_alter_gha_tasks`