### PR TITLE
v91

### DIFF
--- a/macros/python/transform_logs.sql
+++ b/macros/python/transform_logs.sql
@@ -2,7 +2,7 @@
 create or replace function {{ schema }}.udf_transform_logs(decoded variant)
 returns variant 
 language python 
-runtime_version = '3.8' 
+runtime_version = '3.9' 
 handler = 'transform' as $$
 from copy import deepcopy
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v4.0.0-beta.89
+    revision: v4.0.0-beta.91


### PR DESCRIPTION
Requires fsc-evm version upgrade which includes fsc-utils package bump based on [this PR](https://github.com/FlipsideCrypto/fsc-utils/pull/61)