### PR TITLE
fix/cctpv2 address

### DIFF
--- a/data/silver_bridge__cctp_chain_id_seed.csv
+++ b/data/silver_bridge__cctp_chain_id_seed.csv
@@ -10,3 +10,6 @@ polygon pos,7
 sui,8
 aptos,9
 unichain,10
+linea,11
+sonic,13
+worldchain,14

--- a/models/silver/defi/bridge/cctp/silver_bridge__cctp_v2_depositforburn.sql
+++ b/models/silver/defi/bridge/cctp/silver_bridge__cctp_v2_depositforburn.sql
@@ -33,83 +33,55 @@ WITH base_evt AS (
             decoded_log :destinationDomain :: STRING
         ) AS destination_domain,
         CASE
-            WHEN destination_domain IN (
-                0,
-                1,
-                2,
-                3,
-                6,
-                7,
-                10
-            ) THEN CONCAT(
+            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(
+                decoded_log :mintRecipient :: STRING
+            ) -- solana
+            WHEN LEFT(
+                decoded_log :mintRecipient :: STRING,
+                26
+            ) = '0x000000000000000000000000' THEN CONCAT(
                 '0x',
                 SUBSTR(
                     decoded_log :mintRecipient :: STRING,
-                    25,
+                    27,
                     40
                 )
             ) -- evm
-            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(CONCAT('0x', decoded_log :mintRecipient :: STRING)) -- solana
-            ELSE CONCAT(
-                '0x',
-                decoded_log :mintRecipient :: STRING
-            ) -- other non-evm chains
+            ELSE decoded_log :mintRecipient :: STRING -- other non-evm chains
         END AS mint_recipient,
         CASE
-            WHEN destination_domain IN (
-                0,
-                1,
-                2,
-                3,
-                6,
-                7,
-                10
-            ) THEN CONCAT(
+            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(
+                decoded_log :destinationTokenMessenger :: STRING
+            ) -- solana
+            WHEN LEFT(
+                decoded_log :destinationTokenMessenger :: STRING,
+                26
+            ) = '0x000000000000000000000000' THEN CONCAT(
                 '0x',
                 SUBSTR(
                     decoded_log :destinationTokenMessenger :: STRING,
-                    25,
+                    27,
                     40
                 )
             ) -- evm
-            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(
-                CONCAT(
-                    '0x',
-                    decoded_log :destinationTokenMessenger :: STRING
-                )
-            ) -- solana
-            ELSE CONCAT(
-                '0x',
-                decoded_log :destinationTokenMessenger :: STRING
-            ) -- other non-evm chains
+            ELSE decoded_log :destinationTokenMessenger :: STRING -- other non-evm chains
         END AS destination_token_messenger,
         CASE
-            WHEN destination_domain IN (
-                0,
-                1,
-                2,
-                3,
-                6,
-                7,
-                10
-            ) THEN CONCAT(
+            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(
+                decoded_log :destinationCaller :: STRING
+            ) -- solana
+            WHEN LEFT(
+                decoded_log :destinationCaller :: STRING,
+                26
+            ) = '0x000000000000000000000000' THEN CONCAT(
                 '0x',
                 SUBSTR(
                     decoded_log :destinationCaller :: STRING,
-                    25,
+                    27,
                     40
                 )
             ) -- evm
-            WHEN destination_domain = 5 THEN utils.udf_hex_to_base58(
-                CONCAT(
-                    '0x',
-                    decoded_log :destinationCaller :: STRING
-                )
-            ) -- solana
-            ELSE CONCAT(
-                '0x',
-                decoded_log :destinationCaller :: STRING
-            ) -- other non-evm chains
+            ELSE decoded_log :destinationCaller :: STRING -- other non-evm chains
         END AS destination_caller,
         modified_timestamp,
         CONCAT(


### PR DESCRIPTION
Changes:
- fix address logic by removing 0x for non-evm chains
- update logic for evm address by identifying 0x000000000000000000000000 padding instead of hard code.
_(note that noble chain is the only non-evm chain to return address with 0x00... padding
update seed file_
**Deployment Code**
`dbt seed --select data/silver_bridge__cctp_chain_id_seed.csv && dbt run -m models/silver/defi/bridge/cctp/silver_bridge__cctp_v2_depositforburn.sql --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql --vars '{"HEAL_MODELS":"cctp_v2"}'`