### PR TITLE
ethereum/v4.19.3

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v4.19.1
+    revision: v4.19.3


### PR DESCRIPTION
## Summary
- Update fsc-evm package from v4.19.1 to v4.19.3
- Includes symbiosis-v1 bridge recency exclusion to resolve daily test failures

## Test plan
- Daily tests should pass with bridge recency exclusions

🤖 Generated with [Claude Code](https://claude.ai/code)